### PR TITLE
Enabling test_setattr in test_list.py

### DIFF
--- a/batavia/core/native.js
+++ b/batavia/core/native.js
@@ -8,6 +8,7 @@ native.getattr_raw = function(obj, attr, attributes_only) {
         if (attributes_only) {
             return undefined
         }
+        
         // If this is a native Javascript function, wrap the function
         // so that the Python calling convention is used. If it's a
         // class constructor, wrap it in a method that uses the Python

--- a/batavia/core/native.js
+++ b/batavia/core/native.js
@@ -56,6 +56,14 @@ native.getattr = function(obj, attr) {
 }
 
 native.setattr = function(obj, attr, value) {
+    var type_name = require('../core').type_name
+
+    var val = native.getattr_raw(obj, attr)
+    if (val === undefined) {
+        throw new exceptions.AttributeError.$pyclass(
+            "'" + type_name(obj) + "' object has no attribute '" + attr + "'"
+        )
+    }
     obj[attr] = value
 }
 

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -29,7 +29,6 @@ class ListTests(TranspileTestCase):
 
         self.assertCodeExecution(set_up + ''.join(comparisons))
 
-    @unittest.expectedFailure
     def test_setattr(self):
         self.assertCodeExecution("""
             x = [1, 2, 3]


### PR DESCRIPTION
Fixes test test_set_attr by implementing a check type on native.js for setattr to complain if the type does not have that attribute
Removes expectedFailure decorator from this test