### PR TITLE
Window OS : test suite error solved

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1234,9 +1234,9 @@ class BuiltinFunctionTestCase(NotImplementedToExpectedFailure):
                         print('>>> %(format)s%(operation)s')
                         f = %(f)s
                         x = %(x)s
-                        print('|||', %(format)s%(operation)s)
+                        print(%(format)s%(operation)s)
                     except Exception as e:
-                        print('///', type(e), ':', e)
+                        print(type(e), ':', e)
                     print()
                     """ % {
                         'f': function,


### PR DESCRIPTION
1. Describe your changes in detail 
   - I have eliminated the code('|||' and '///') in assertBinaryOperation() in class BuiltinFunctionTestCase(NotImplementedToExpectedFailure)s 

2. What problem does this change solve? 
   - With Windows Environment, test suites gives too much fails

3. If this PR relates to an issue, include Refs #xxx or Fixes #xxx
   - issue number 685

