### PR TITLE
Fix issue #735 - Wrong error type returned by pow function

### DIFF
--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -21,7 +21,7 @@ function pow(args, kwargs) {
             throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
         }
         if (y < 0) {
-            throw new exceptions.TypeError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
+            throw new exceptions.ValueError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
         }
         if (y === 0) {
             return 1


### PR DESCRIPTION
Fixed issue #735. Pow function now returns ValueError
instead of TypeError when it has got 3 arguments and
second one is negative.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
