### PR TITLE
fix: Ensure `pow(3, -4, 5)` throws ValueError

### DIFF
--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -1,8 +1,8 @@
-var exceptions = require('../core').exceptions
-var types = require('../types')
+const exceptions = require('../core').exceptions
+const types = require('../types')
 
 function pow(args, kwargs) {
-    var x, y, z
+    let x, y, z
     if (!args) {
         throw new exceptions.TypeError.$pyclass('pow expected at least 2 arguments, got 0')
     }
@@ -21,7 +21,7 @@ function pow(args, kwargs) {
             throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
         }
         if (y < 0) {
-            throw new exceptions.TypeError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
+            throw new exceptions.ValueError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
         }
 
         // if z is 1 or -1 then answer is always 0
@@ -30,14 +30,14 @@ function pow(args, kwargs) {
         }
 
         // if y is 0 provided z is not 1 or -1, then answer is always 1
-        if (parseInt(y) == 0) {
+        if (parseInt(y) === 0) {
             return 1
         }
 
         // right-to-left exponentiation to reduce memory and time
         // See https://en.wikipedia.org/wiki/Modular_exponentiation#Right-to-left_binary_method
-        var result = 1
-        var base = x % z
+        let result = 1
+        let base = x % z
         while (y > 0) {
             if ((y & 1) === 1) {
                 result = (result * base) % z

--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -21,7 +21,13 @@ function pow(args, kwargs) {
             throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
         }
         if (y < 0) {
-            throw new exceptions.ValueError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
+            const version = require('../core').version
+            const error_message = 'pow() 2nd argument cannot be negative when 3rd argument specified'
+            if (version.earlier('3.4')) {
+                throw new exceptions.TypeError.$pyclass(error_message)
+            } else {
+                throw new exceptions.ValueError.$pyclass(error_message)
+            }
         }
 
         // if z is 1 or -1 then answer is always 0
@@ -53,3 +59,4 @@ function pow(args, kwargs) {
 pow.__doc__ = 'pow(x, y[, z]) -> number\n\nWith two arguments, equivalent to x**y.  With three arguments,\nequivalent to (x**y) % z, but may be more efficient (e.g. for ints).'
 
 module.exports = pow
+

--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -23,7 +23,7 @@ function pow(args, kwargs) {
         if (y < 0) {
             const version = require('../core').version
             const error_message = 'pow() 2nd argument cannot be negative when 3rd argument specified'
-            if (version.earlier('3.4')) {
+            if (version.earlier('3.5')) {
                 throw new exceptions.TypeError.$pyclass(error_message)
             } else {
                 throw new exceptions.ValueError.$pyclass(error_message)


### PR DESCRIPTION
`pow(x, y, z)` throw a `ValueError` when `y` is negative, while `x`, and ,`z` are positive.

Additionally cleaned up the javascript with ECMAscript 6 recommendations; i.e. the use of `let`, or `const` instead of `var`, and triple `=` instead of double.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Related issue: #46

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
