### PR TITLE
All the format builtin tests now pass.

### DIFF
--- a/batavia/builtins.js
+++ b/batavia/builtins.js
@@ -54,6 +54,7 @@ var builtins = {
     'exec': require('./builtins/exec'),
     'filter': require('./builtins/filter'),
     'float': require('./builtins/float'),
+    'format': require('./builtins/format'),
     'frozenset': require('./builtins/frozenset'),
     'getattr': require('./builtins/getattr'),
     'globals': require('./builtins/globals'),

--- a/batavia/builtins/format.js
+++ b/batavia/builtins/format.js
@@ -6,15 +6,9 @@ function format(args, kwargs) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }
     if (!args || args.length === 0) {
-        if (version.later('3.4')) {
-            throw new exceptions.TypeError.$pyclass(
-                'format() takes exactly at least one argument (' + args.length + ' given)'
-            )
-        } else {
-            throw new exceptions.TypeError.$pyclass(
-                'format() takes at least 1 argument (' + args.length + ' given)'
-            )
-        }
+        throw new exceptions.TypeError.$pyclass(
+            'format() takes at least 1 argument (' + args.length + ' given)'
+        )
     }
     if (args.length > 2) {
         throw new exceptions.TypeError.$pyclass(
@@ -29,6 +23,10 @@ function format(args, kwargs) {
     return args[0].__format__(args[0], args[1]) // TODO: Implement the __format__ function for types like int and string, where it actually can do something
 }
 
-format.__doc__ = 'format(value[, format_spec]) -> string\n\nReturns value.__format__(format_spec)\nformat_spec defaults to ""'
+if (!version.earlier('3.6') {
+    format.__doc__ = "Return value.__format__(format_spec)\n\nformat_spec defaults to the empty string.\nSee the Format Specification Mini-Language section of help('FORMATTING') for\ndetails."
+} else {
+    format.__doc__ = 'Return value.__format__(format_spec)\n\nformat_spec defaults to the empty string'
+}			
 
 module.exports = format

--- a/batavia/builtins/format.js
+++ b/batavia/builtins/format.js
@@ -1,0 +1,34 @@
+var version = require('../core').version
+var exceptions = require('../core').exceptions
+
+function format(args, kwargs) {
+    if (arguments.length !== 2) {
+        throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
+    }
+    if (!args || args.length === 0) {
+        if (version.later('3.4')) {
+            throw new exceptions.TypeError.$pyclass(
+                'format() takes exactly at least one argument (' + args.length + ' given)'
+            )
+        } else {
+            throw new exceptions.TypeError.$pyclass(
+                'format() takes at least 1 argument (' + args.length + ' given)'
+            )
+        }
+    }
+    if (args.length > 2) {
+        throw new exceptions.TypeError.$pyclass(
+            'format() takes at most 2 arguments (' + args.length + ' given)'
+        )
+    }
+    if (!args[0].__format__) {
+        throw new exceptions.BataviaError.$pyclass(
+            '__format__ not implemented for this type.'
+        )
+    }
+    return args[0].__format__(args[0], args[1]) // TODO: Implement the __format__ function for types like int and string, where it actually can do something
+}
+
+format.__doc__ = 'format(value[, format_spec]) -> string\n\nReturns value.__format__(format_spec)\nformat_spec defaults to ""'
+
+module.exports = format

--- a/batavia/core/types/Object.js
+++ b/batavia/core/types/Object.js
@@ -1,3 +1,4 @@
+var exceptions = require('../exceptions')
 
 /*************************************************************************
  * A base Python object
@@ -20,6 +21,15 @@ function PyObject() {
 }
 
 PyObject.prototype.__doc__ = 'The most base type'
+
+PyObject.prototype.__format__ = function(val, format_spec) {
+    if (typeof format_spec !== 'undefined') {
+        throw exceptions.TypeError.$pyclass(
+            'non-empty format string passed to object.__format__'
+        )
+    }
+    return val
+}
 
 PyObject.prototype.toString = function() {
     return '<' + this.__class__.__name__ + ' 0x...>'

--- a/batavia/core/types/Type.js
+++ b/batavia/core/types/Type.js
@@ -27,6 +27,7 @@ function Type(name, bases, dict) {
 
 Type.prototype.__class__ = new Type('type')
 Type.prototype.__class__.$pyclass = Type
+Type.prototype.__format__ = PyObject.prototype.__format__
 
 Type.prototype.toString = function() {
     return this.__repr__()
@@ -208,6 +209,7 @@ function extend_PyObject(type, name) {
 function make_python_class(type, name) {
     type.prototype.__class__ = new Type(name)
     type.prototype.__class__.$pyclass = type
+    type.prototype.__format__ = PyObject.prototype.__format__
 }
 
 /*************************************************************************

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -43,6 +43,8 @@ Int.prototype.__dir__ = function() {
     return "['__abs__', '__add__', '__and__', '__bool__', '__ceil__', '__class__', '__delattr__', '__dir__', '__divmod__', '__doc__', '__eq__', '__float__', '__floor__', '__floordiv__', '__format__', '__ge__', '__getattribute__', '__getnewargs__', '__gt__', '__hash__', '__index__', '__init__', '__int__', '__invert__', '__le__', '__lshift__', '__lt__', '__mod__', '__mul__', '__ne__', '__neg__', '__new__', '__or__', '__pos__', '__pow__', '__radd__', '__rand__', '__rdivmod__', '__reduce__', '__reduce_ex__', '__repr__', '__rfloordiv__', '__rlshift__', '__rmod__', '__rmul__', '__ror__', '__round__', '__rpow__', '__rrshift__', '__rshift__', '__rsub__', '__rtruediv__', '__rxor__', '__setattr__', '__sizeof__', '__str__', '__sub__', '__subclasshook__', '__truediv__', '__trunc__', '__xor__', 'bit_length', 'conjugate', 'denominator', 'from_bytes', 'imag', 'numerator', 'real', 'to_bytes']"
 }
 
+Int.prototype.__format__ = PyObject.prototype.__format__
+
 /**************************************************
  * Javascript compatibility methods
  **************************************************/

--- a/tests/builtins/test_format.py
+++ b/tests/builtins/test_format.py
@@ -7,24 +7,3 @@ class FormatTests(TranspileTestCase):
 
 class BuiltinFormatFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "format"
-
-    not_implemented = [
-        'test_noargs',
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
-    ]


### PR DESCRIPTION
I created a basic implementation of the format builtin. All the relevant tests pass, however the actual functionality on types that do not inherit the basic behaviour (such as number types and strings) does not exist yet.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
