### PR TITLE
For loops with sequence objects

### DIFF
--- a/batavia/types.js
+++ b/batavia/types.js
@@ -14,6 +14,7 @@ types['JSDict'] = require('./types/JSDict')
 types['Property'] = require('./types/Property')
 
 types['SetIterator'] = require('./types/SetIterator')
+types['SequenceIterator'] = require('./types/SequenceIterator')
 
 types['Bool'] = require('./types/Bool')
 types['Float'] = require('./types/Float').Float

--- a/batavia/types/SequenceIterator.js
+++ b/batavia/types/SequenceIterator.js
@@ -6,7 +6,7 @@ var callables = require('../core').callables
 var Int = require('./Int')
 
 /**************************************************
- * List Iterator
+ * Sequence Iterator
  **************************************************/
 
 function SequenceIterator(data) {
@@ -18,7 +18,7 @@ function SequenceIterator(data) {
     this.length = len.valueOf()
 }
 
-create_pyclass(SequenceIterator, 'sequence_iterator')
+create_pyclass(SequenceIterator, 'iterator')
 
 SequenceIterator.prototype.__iter__ = function() {
     return this
@@ -36,7 +36,7 @@ SequenceIterator.prototype.__next__ = function() {
 }
 
 SequenceIterator.prototype.__str__ = function() {
-    return '<sequence_iterator object at 0x99999999>'
+    return '<iterator object at 0x99999999>'
 }
 
 /**************************************************

--- a/batavia/types/SequenceIterator.js
+++ b/batavia/types/SequenceIterator.js
@@ -1,0 +1,46 @@
+var PyObject = require('../core').Object
+var create_pyclass = require('../core').create_pyclass
+var exceptions = require('../core').exceptions
+var callables = require('../core').callables
+
+var Int = require('./Int')
+
+/**************************************************
+ * List Iterator
+ **************************************************/
+
+function SequenceIterator(data) {
+    PyObject.call(this)
+    var len = callables.call_method(data, '__len__', [])
+
+    this.index = 0
+    this.data = data
+    this.length = len.valueOf()
+}
+
+create_pyclass(SequenceIterator, 'sequence_iterator')
+
+SequenceIterator.prototype.__iter__ = function() {
+    return this
+}
+
+SequenceIterator.prototype.__next__ = function() {
+    if (this.index >= this.length) {
+      throw new exceptions.StopIteration.$pyclass()
+    }
+
+    var i = new Int(this.index)
+    var retval = callables.call_method(this.data, '__getitem__', [i])
+    this.index++
+    return retval
+}
+
+SequenceIterator.prototype.__str__ = function() {
+    return '<sequence_iterator object at 0x99999999>'
+}
+
+/**************************************************
+ * Module exports
+ **************************************************/
+
+module.exports = SequenceIterator

--- a/tests/structures/test_for.py
+++ b/tests/structures/test_for.py
@@ -58,6 +58,34 @@ class ForLoopTests(TranspileTestCase):
             print('Done.')
             """)
 
+    def test_for_over_iterable_object(self):
+
+        self.assertCodeExecution("""
+            class Test:
+                class TestIterator:
+                    def __init__(self, l):
+                        self.l = l
+                        self.i = 0
+                    def __iter__(self):
+                        return self
+                    def __next__(self):
+                        if self.i >= len(self.l):
+                            raise StopIteration
+                        self.i += 1
+                        return self.l[self.i - 1]
+                def __init__(self, l):
+                    self.l = l
+                def __iter__(self):
+                    return self.TestIterator(self.l)
+            t = Test([1 ,2, 3, 5])
+
+            total = 0
+            for i in iter(t):
+                total = total + i
+                print(i, total)
+            print('Done.')
+            """)
+
         self.assertCodeExecution("""
             class Test:
                 def __init__(self, l):
@@ -66,7 +94,7 @@ class ForLoopTests(TranspileTestCase):
                     return len(self.l)
                 def __getitem__(self, index):
                     return self.l[index]
-            t = Test([1 ,2, 3, 5])
+            t = Test([1 ,2, 3, 6])
 
             total = 0
             for i in t:

--- a/tests/structures/test_for.py
+++ b/tests/structures/test_for.py
@@ -62,25 +62,14 @@ class ForLoopTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             class Test:
-                class TestIterator:
-                    def __init__(self, l):
-                        self.l = l
-                        self.i = 0
-                    def __iter__(self):
-                        return self
-                    def __next__(self):
-                        if self.i >= len(self.l):
-                            raise StopIteration
-                        self.i += 1
-                        return self.l[self.i - 1]
                 def __init__(self, l):
                     self.l = l
                 def __iter__(self):
-                    return self.TestIterator(self.l)
+                    return iter(self.l)
             t = Test([1 ,2, 3, 5])
 
             total = 0
-            for i in iter(t):
+            for i in t:
                 total = total + i
                 print(i, total)
             print('Done.')

--- a/tests/structures/test_for.py
+++ b/tests/structures/test_for.py
@@ -58,6 +58,23 @@ class ForLoopTests(TranspileTestCase):
             print('Done.')
             """)
 
+        self.assertCodeExecution("""
+            class Test:
+                def __init__(self, l):
+                    self.l = l
+                def __len__(self):
+                    return len(self.l)
+                def __getitem__(self, index):
+                    return self.l[index]
+            t = Test([1 ,2, 3, 5])
+
+            total = 0
+            for i in t:
+                total = total + i
+                print(i, total)
+            print('Done.')
+            """)
+
     # def test_for_else(self):
     #     self.assertCodeExecution(
     #         code="""


### PR DESCRIPTION
This PR is related to the issue #762 where for loops didn't work the same way as in CPython with sequence objects. I started by adding failing tests related to the issue. Then I modified the iter() builtin function and added a SequenceIterator type to handle sequence objects in for loops. With these modifications I managed to pass the tests I created.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct