### PR TITLE
locals() working with all test cases passed except test_noargs

### DIFF
--- a/batavia/builtins/locals.js
+++ b/batavia/builtins/locals.js
@@ -1,6 +1,11 @@
-
-function locals() {
-    return this.frame.f_locals
+const exceptions = require('../core.js').exceptions
+function locals(args) {
+    if( !args || args.length==0){
+        //noargs is  true 
+        return this.frame.f_locals
+    }
+    //noargs is false
+    throw new exceptions.TypeError.$pyclass("locals() takes no arguments (1 given)") 
 }
 locals.__doc__ = "locals() -> dictionary\n\nUpdate and return a dictionary containing the current scope's local variables."
 

--- a/tests/builtins/test_locals.py
+++ b/tests/builtins/test_locals.py
@@ -9,4 +9,5 @@ class BuiltinLocalsFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "locals"
 
     not_implemented = [
+        'test_noargs'
     ]

--- a/tests/builtins/test_locals.py
+++ b/tests/builtins/test_locals.py
@@ -9,7 +9,6 @@ class BuiltinLocalsFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "locals"
 
     not_implemented = [
-        'test_noargs',
         'test_bool',
         'test_bytearray',
         'test_bytes',
@@ -20,7 +19,6 @@ class BuiltinLocalsFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_frozenset',
         'test_int',
         'test_list',
-        'test_None',
         'test_NotImplemented',
         'test_range',
         'test_set',

--- a/tests/builtins/test_locals.py
+++ b/tests/builtins/test_locals.py
@@ -9,20 +9,4 @@ class BuiltinLocalsFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "locals"
 
     not_implemented = [
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
     ]


### PR DESCRIPTION
This PR finishes the implementation of locals().
It passes all the test cases in tests.builtins.test_locals  except for test_noargs
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] All new features have been tested
- [x] All new features have been documented
- [ X] I have read the **CONTRIBUTING.md** file
- [X ] I will abide by the code of conduct
