### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='russell@keith-magee.com',
     url=data['homepage'],
     packages=find_packages(exclude=['docs', 'tests']),
-    python_requires='>=3.4, <=3.5',
+    python_requires='>=3.4, <=3.6',
     license='New BSD',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='russell@keith-magee.com',
     url=data['homepage'],
     packages=find_packages(exclude=['docs', 'tests']),
-    python_requires='>=3.4, <=3.6',
+    python_requires='>=3.4, <3.7',
     license='New BSD',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development',
         'Topic :: Utilities',


### PR DESCRIPTION
Expands allowed versions to include python 3.6

<!--- Describe your changes in detail -->
Updated python requires and classifiers to include 3.6
<!--- What problem does this change solve? -->
It allows the use of python 3.6 and versions of 3.5 beyond 3.5.0
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
