### PR TITLE
Fix filename in contribute-docs.rst

### DIFF
--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -22,7 +22,7 @@ Go to the documentation folder: ::
 
 Install Sphinx with the helpers and extensions we use: ::
 
-    $ pip install -r requirements_docs.txt
+    $ pip install -r requirements_rtd.txt
 
 Create the static files: ::
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
There was a small error in the filename in the "how-to" instruction page. The error is fixed.

<!--- What problem does this change solve? -->
Following the instructions word by word resulted in an 'no such file or directory' error. Eliminates the prospect of such error.
 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
