### PR TITLE
Update some error messages to match new python versions

### DIFF
--- a/batavia/builtins/bytearray.js
+++ b/batavia/builtins/bytearray.js
@@ -1,6 +1,7 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 var type_name = require('../core').type_name
+var version = require('../core').version
 
 function nonNumericFilter(value) {
     return /\D/.test(value)
@@ -8,6 +9,14 @@ function nonNumericFilter(value) {
 
 function asBytes(value) {
     return new types.Bytes(value)
+}
+
+function requiresInteger(value) {
+    if (version.later('3.6')) {
+        throw new exceptions.TypeError.$pyclass("'" + type_name(value) + "' object cannot be interpreted as an integer")
+    } else {
+        throw new exceptions.TypeError.$pyclass('an integer is required')
+    }
 }
 
 function bytearray(args, kwargs) {
@@ -52,14 +61,14 @@ function bytearray(args, kwargs) {
         var toConvert = args[0].keys()
         let nonDigits = toConvert.filter(nonNumericFilter)
         if (nonDigits.length > 0) {
-            throw new exceptions.TypeError.$pyclass('an integer is required')
+            requiresInteger(nonDigits[0])
         }
         return new types.Bytearray(toConvert.map(asBytes))
     } else if (types.isinstance(args[0], [types.FrozenSet, types.Set])) {
         var asList = new types.List(args[0].data.keys())
         let nonDigits = asList.filter(nonNumericFilter)
         if (nonDigits.length > 0) {
-            throw new exceptions.TypeError.$pyclass('an integer is required')
+            requiresInteger(nonDigits[0])
         }
         return new types.Bytearray(asList.map(function(value) {
             return asBytes([value])
@@ -98,7 +107,7 @@ function bytearray(args, kwargs) {
             return !types.isinstance(value, [types.Int, types.Bool])
         })
         if (nonDigits.length > 0) {
-            throw new exceptions.TypeError.$pyclass('an integer is required')
+            requiresInteger(nonDigits[0])
         }
         return new types.Bytearray(new types.Bytes(toConvert))
     } else if (types.isinstance(args[0], types.Str)) {

--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -1,4 +1,5 @@
 var exceptions = require('../core').exceptions
+var version = require('../core').version
 var types = require('../types')
 
 function pow(args, kwargs) {
@@ -21,7 +22,12 @@ function pow(args, kwargs) {
             throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
         }
         if (y < 0) {
-            throw new exceptions.TypeError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
+            let message = 'pow() 2nd argument cannot be negative when 3rd argument specified'
+            if (version.later('3.5')) {
+                throw new exceptions.ValueError.$pyclass(message)
+            } else {
+                throw new exceptions.TypeError.$pyclass(message)
+            }
         }
 
         // if z is 1 or -1 then answer is always 0

--- a/batavia/builtins/sorted.js
+++ b/batavia/builtins/sorted.js
@@ -1,5 +1,6 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
+var version = require('../core').version
 
 function _validateInput(args, kwargs) {
     var bigger = 1
@@ -35,7 +36,11 @@ function _validateInput(args, kwargs) {
     }
 
     if (args === undefined || args.length === 0) {
-        throw new exceptions.TypeError.$pyclass("Required argument 'iterable' (pos 1) not found")
+        if (version.later('3.6')) {
+            throw new exceptions.TypeError.$pyclass('Function takes at least 1 positional arguments (0 given)')
+        } else {
+            throw new exceptions.TypeError.$pyclass("Required argument 'iterable' (pos 1) not found")
+        }
     }
 
     return {

--- a/tests/builtins/test_bytearray.py
+++ b/tests/builtins/test_bytearray.py
@@ -8,10 +8,7 @@ class BytearrayTests(TranspileTestCase):
 class BuiltinBytearrayFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "bytearray"
 
-    not_implemented_versions = {
-        'test_dict': ['3.6'],
-        'test_frozenset': ['3.6'],
-        'test_list': ['3.6'],
-        'test_set': ['3.6'],
-        'test_tuple': ['3.6'],
-    }
+    is_flakey = [
+        'test_set',
+        'test_frozenset',
+    ]

--- a/tests/builtins/test_pow.py
+++ b/tests/builtins/test_pow.py
@@ -11,7 +11,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
         """)
 
-    @expected_failing_versions(['3.5', '3.6'])
     def test_int_neg_y_pos_z(self):
         self.assertCodeExecution("""
             x = 3
@@ -20,7 +19,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
         """)
 
-    @expected_failing_versions(['3.5', '3.6'])
     def test_int_neg_y_neg_z(self):
         self.assertCodeExecution("""
             x = 3


### PR DESCRIPTION
This cleans up some of the current errors in the tests at head by updating the error messages to match the behaviour of 3.5 and 3.6 as necessary.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
