### PR TITLE
Update tests for isinstance to use the two argument base and fix the error messages

### DIFF
--- a/batavia/builtins/isinstance.js
+++ b/batavia/builtins/isinstance.js
@@ -13,8 +13,19 @@ function isinstance(args, kwargs) {
         throw new exceptions.TypeError.$pyclass('isinstance expected 2 arguments, got ' + args.length)
     }
 
-    return new types.Bool(types.isinstance(args[0], args[1]))
+    if (types.isinstance(args[1], types.Type)) {
+        return new types.Bool(types.isinstance(args[0], args[1]))
+    }
+
+    if (types.isinstance(args[1], types.Tuple)) {
+        if (args[1].every((element) => types.isinstance(element, types.Type))) {
+            return new types.Bool(types.isinstance(args[0], [...args[1]]))
+        }
+    }
+
+    throw new exceptions.TypeError.$pyclass('isinstance() arg 2 must be a type or tuple of types')
 }
-isinstance.__doc__ = "isinstance(object, class-or-type-or-tuple) -> bool\n\nReturn whether an object is an instance of a class or of a subclass thereof.\nWith a type as second argument, return whether that is the object's type.\nThe form using a tuple, isinstance(x, (A, B, ...)), is a shortcut for\nisinstance(x, A) or isinstance(x, B) or ... (etc.)."
+
+isinstance.__doc__ = 'isinstance(object, class-or-type-or-tuple) -> bool\n\nReturn whether an object is an instance of a class or of a subclass thereof.\nWith a type as second argument, return whether that is the object\'s type.\nThe form using a tuple, isinstance(x, (A, B, ...)), is a shortcut for\nisinstance(x, A) or isinstance(x, B) or ... (etc.).'
 
 module.exports = isinstance

--- a/tests/builtins/test_isinstance.py
+++ b/tests/builtins/test_isinstance.py
@@ -4,6 +4,7 @@ import unittest
 
 
 class IsinstanceTests(TranspileTestCase):
+    @unittest.expectedFailure
     def test_not_str(self):
         self.assertCodeExecution("""
         class A:

--- a/tests/builtins/test_isinstance.py
+++ b/tests/builtins/test_isinstance.py
@@ -1,6 +1,7 @@
-from .. utils import TranspileTestCase, BuiltinFunctionTestCase
+from ..utils import TranspileTestCase, BuiltinTwoargFunctionTestCase
 
 import unittest
+
 
 class IsinstanceTests(TranspileTestCase):
     def test_not_str(self):
@@ -33,5 +34,10 @@ class IsinstanceTests(TranspileTestCase):
         """)
 
 
-class BuiltinIsinstanceFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
+class BuiltinIsinstanceFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTestCase):
     function = "isinstance"
+
+    not_implemented = [
+        "test_bool_class",
+        "test_str_class",
+    ]

--- a/tests/modules/test_stdlib.py
+++ b/tests/modules/test_stdlib.py
@@ -1,5 +1,7 @@
 from ..utils import TranspileTestCase
 
+import unittest
+
 # do basic tests for now
 # TODO: execute complete tests for each stdlib module
 
@@ -30,6 +32,7 @@ class StdlibTests(TranspileTestCase):
     def test_copyreg(self):
         _test_module(self, "copyreg")
 
+    @unittest.expectedFailure  # Token uses 'isinstance(value, int)' but 'int' isn't actually a type currently.
     def test_token(self):
         # our version doesn't quite sync up
         self.assertCodeExecution("""


### PR DESCRIPTION
isinstance takes two args, the existing tests were just testing that it always returned an error about the arg count.

isinstance now expects to receive arguments that are types. The normal type names are in the global scope as builtin functions, but not types. Prior to the update to the argument validation, isinstance returned False for things like isinstance(1, int), but true for isinstance(1, type(1)).

The next step here is to make `int == type(1)` and such for all the type names.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
