### PR TITLE
Fix isinstance for most types.

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1488,7 +1488,7 @@ VirtualMachine.prototype.byte_UNPACK_SEQUENCE = function(count) {
 VirtualMachine.prototype.byte_BUILD_SLICE = function(count) {
     if (count === 2 || count === 3) {
         var items = this.popn(count)
-        this.push(builtins.slice(items))
+        this.push(callables.call_function(builtins.slice, items, {}))
     } else {
         throw new builtins.BataviaError.$pyclass('Strange BUILD_SLICE count: ' + count)
     }

--- a/batavia/builtins/bool.js
+++ b/batavia/builtins/bool.js
@@ -3,7 +3,9 @@ var callables = require('../core').callables
 var type_name = require('../core').type_name
 var types = require('../types')
 
-function bool(args, kwargs) {
+var bool = types.Bool.prototype.__class__
+
+bool.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/bytearray.js
+++ b/batavia/builtins/bytearray.js
@@ -3,6 +3,8 @@ var types = require('../types')
 var type_name = require('../core').type_name
 var version = require('../core').version
 
+var bytearray = types.Bytearray.prototype.__class__
+
 function nonNumericFilter(value) {
     return /\D/.test(value)
 }
@@ -19,7 +21,7 @@ function requiresInteger(value) {
     }
 }
 
-function bytearray(args, kwargs) {
+bytearray.__call__ = function(args, kwargs) {
 //    bytearray(string, encoding[, errors]) -> bytearray
 //    bytearray(bytes_or_buffer) -> mutable copy of bytes_or_buffer
 //    bytearray(iterable_of_ints) -> bytearray

--- a/batavia/builtins/bytes.js
+++ b/batavia/builtins/bytes.js
@@ -7,7 +7,9 @@ var version = require('../core').version
 var types = require('../types')
 var iter = require('./iter')
 
-function bytes(args, kwargs) {
+var bytes = types.Bytes.prototype.__class__
+
+bytes.__call__ = function(args, kwargs) {
 //    bytes(iterable_of_ints) -> bytes
 //    bytes(string, encoding[, errors]) -> bytes
 //    bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer
@@ -65,7 +67,7 @@ function bytes(args, kwargs) {
             }
         } else if (types.isinstance(arg, types.Bool)) {
             // Python bool is subclassed from int, but Batavia's Boolean is a fake int:
-            return bytes([arg.__int__()], [])
+            return callables.call_function(bytes, [arg.__int__()], {})
         } else if (types.isinstance(arg, types.Bytes)) {
             // bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer
             return new types.Bytes(Buffer.from(arg.val))

--- a/batavia/builtins/complex.js
+++ b/batavia/builtins/complex.js
@@ -1,7 +1,9 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 
-function complex(args, kwargs) {
+var complex = types.Complex.prototype.__class__
+
+complex.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/dict.js
+++ b/batavia/builtins/dict.js
@@ -2,7 +2,9 @@ var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
 var types = require('../types')
 
-function dict(args, kwargs) {
+var dict = types.Dict.prototype.__class__
+
+dict.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/filter.js
+++ b/batavia/builtins/filter.js
@@ -1,7 +1,9 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 
-function filter(args, kwargs) {
+var filter = types.Filter.prototype.__class__
+
+filter.__call__ = function(args, kwargs) {
     if (args.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/float.js
+++ b/batavia/builtins/float.js
@@ -1,9 +1,12 @@
+var callables = require('../core').callables
 var exceptions = require('../core').exceptions
 var str = require('./str')
 var type_name = require('../core').type_name
 var types = require('../types')
 
-function float(args, kwargs) {
+var float = types.Float.prototype.__class__
+
+float.__call__ = function(args, kwargs) {
     if (args.length > 1) {
         throw new exceptions.TypeError.$pyclass('float() takes at most 1 argument (' + args.length + ' given)')
     }
@@ -23,7 +26,7 @@ function float(args, kwargs) {
         var was_byte_object = false
         if (types.isinstance(value, [types.Bytes, types.Bytearray])) {
             was_byte_object = true
-            value = str([value], null)
+            value = callables.call_function(str, [value], null)
         }
         if (value.length === 0 || value === "b''" || value === "bytearray''") {
             throw new exceptions.ValueError.$pyclass('could not convert string to float: ')

--- a/batavia/builtins/frozenset.js
+++ b/batavia/builtins/frozenset.js
@@ -1,7 +1,9 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 
-function frozenset(args, kwargs) {
+var frozenset = types.FrozenSet.prototype.__class__
+
+frozenset.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/int.js
+++ b/batavia/builtins/int.js
@@ -1,10 +1,13 @@
+var callables = require('../core').callables
 var exceptions = require('../core').exceptions
 var types = require('../types')
 var type_name = require('../core').type_name
 var bytes = require('./bytes')
 var repr = require('./repr')
 
-function int(args, kwargs) {
+var int = types.Int.prototype.__class__
+
+int.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }
@@ -42,7 +45,7 @@ function int(args, kwargs) {
     }
     // The CPython int() implementation appears to resolve bytearrays to bytes objects before reporting ValueErrors
     if (types.isinstance(value, types.Bytearray)) {
-        value = bytes([value], null)
+        value = callables.call_function(bytes, [value], {})
     }
     // TODO: this should be able to parse things longer than 53 bits
     var result = parseInt(value, base)

--- a/batavia/builtins/list.js
+++ b/batavia/builtins/list.js
@@ -1,6 +1,8 @@
 var types = require('../types')
 
-function list(args) {
+var list = types.List.prototype.__class__
+
+list.__call__ = function(args) {
     if (!args || args.length === 0) {
         return new types.List()
     }

--- a/batavia/builtins/map.js
+++ b/batavia/builtins/map.js
@@ -1,7 +1,9 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 
-function map(args, kwargs) {
+var map = types.Map.prototype.__class__
+
+map.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/range.js
+++ b/batavia/builtins/range.js
@@ -1,7 +1,9 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 
-function range(args, kwargs) {
+var range = types.Range.prototype.__class__
+
+range.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/set.js
+++ b/batavia/builtins/set.js
@@ -1,7 +1,9 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 
-function set(args, kwargs) {
+var set = types.Set.prototype.__class__
+
+set.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/slice.js
+++ b/batavia/builtins/slice.js
@@ -2,7 +2,9 @@ var exceptions = require('../core').exceptions
 var types = require('../types')
 var None = require('../core').None
 
-function slice(args, kwargs) {
+var slice = types.Slice.prototype.__class__
+
+slice.__call__ = function(args, kwargs) {
     if (!args || args.length === 0) {
         throw new exceptions.TypeError.$pyclass('slice expected at least 1 arguments, got 0')
     } else if (args.length === 1) {

--- a/batavia/builtins/str.js
+++ b/batavia/builtins/str.js
@@ -1,6 +1,9 @@
 var exceptions = require('../core').exceptions
+var types = require('../types')
 
-function str(args, kwargs) {
+var str = types.Str.prototype.__class__
+
+str.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/builtins/tuple.js
+++ b/batavia/builtins/tuple.js
@@ -1,11 +1,14 @@
 var types = require('../types')
 
-function tuple(args, kwargs) {
+var tuple = types.Tuple.prototype.__class__
+
+tuple.__class__ = function(args, kwargs) {
     if (args.length === 0) {
         return new types.Tuple()
     }
     return new types.Tuple(args[0])
 }
+
 tuple.__doc__ = "tuple() -> empty tuple\ntuple(iterable) -> tuple initialized from iterable's items\n\nIf the argument is a tuple, the return value is the same object."
 
 module.exports = tuple

--- a/batavia/builtins/type.js
+++ b/batavia/builtins/type.js
@@ -1,7 +1,9 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
 
-var type = function(args, kwargs) {
+var type = types.Type.prototype.__class__
+
+type.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/types.js
+++ b/batavia/types.js
@@ -68,14 +68,14 @@ types.isinstance = function(obj, type) {
                 if (typeof type === 'function' && (type.name === 'bool' || type.name === 'bound bool')) {
                     return true
                 }
-                return type === types.Bool
+                return type === types.Bool || type === types.Bool.prototype.__class__
             case 'number':
-                return type === types.Int
+                return type === types.Int || type === types.Int.prototype.__class__
             case 'string':
                 if (typeof type === 'function' && (type.name === 'str' || type.name === 'bound str')) {
                     return true
                 }
-                return type === types.Str
+                return type === types.Str || type === types.Str.prototype.__class__
             case 'object':
                 if (typeof type === 'object' && obj && obj.__class__) {
                     var leftName = obj.__class__.__name__

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -6,7 +6,6 @@ var version = require('../core').version
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
-var utils = require('./utils')
 
 /*************************************************************************
  * A Python int type

--- a/batavia/types/StrUtils.js
+++ b/batavia/types/StrUtils.js
@@ -1,3 +1,4 @@
+var callables = require('../core').callables
 var exceptions = require('../core').exceptions
 var version = require('../core').version
 var type_name = require('../core').type_name
@@ -1163,7 +1164,7 @@ function _new_subsitute(str, args, kwargs) {
                 case '!a':
                     return builtins.ascii([rawValue], {})
                 default:
-                    return builtins.str([rawValue], {})
+                    return callables.call_function(builtins.str, [rawValue], {})
 
             } // end switch
         }

--- a/tests/builtins/test_isinstance.py
+++ b/tests/builtins/test_isinstance.py
@@ -1,10 +1,9 @@
-from ..utils import TranspileTestCase, BuiltinTwoargFunctionTestCase
+from ..utils import TranspileTestCase, BuiltinFunctionTestCase, BuiltinTwoargFunctionTestCase
 
 import unittest
 
 
 class IsinstanceTests(TranspileTestCase):
-    @unittest.expectedFailure
     def test_not_str(self):
         self.assertCodeExecution("""
         class A:
@@ -12,7 +11,6 @@ class IsinstanceTests(TranspileTestCase):
         print(isinstance(A(), str))
         """)
 
-    @unittest.expectedFailure
     def test_common_types(self):
         self.assertCodeExecution("""
         print(isinstance(1, int))
@@ -35,10 +33,98 @@ class IsinstanceTests(TranspileTestCase):
         """)
 
 
+class BoolIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, bool)"
+    not_implemented = ["test_noargs"]
+
+
+class BytearrayIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, bytearray)"
+    not_implemented = ["test_noargs"]
+
+
+class BytesIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, bytes)"
+    not_implemented = ["test_noargs"]
+
+
+class ComplexIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, complex)"
+    not_implemented = ["test_noargs"]
+
+
+class DictIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, dict)"
+    not_implemented = ["test_noargs"]
+
+
+class FilterIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, filter)"
+    not_implemented = ["test_noargs"]
+
+
+class FloatIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, float)"
+    not_implemented = ["test_noargs"]
+
+
+class FrozensetIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, frozenset)"
+    not_implemented = ["test_noargs"]
+
+
+class IntIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, int)"
+    not_implemented = [
+        "test_bool",
+        "test_noargs",
+    ]
+
+
+class ListIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, list)"
+    not_implemented = ["test_noargs"]
+
+
+class MapIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, map)"
+    not_implemented = ["test_noargs"]
+
+
+@unittest.expectedFailure
+class MemoryviewIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, memoryview)"
+    not_implemented = ["test_noargs"]
+
+
+class RangeIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, range)"
+    not_implemented = ["test_noargs"]
+
+
+class SetIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, set)"
+    not_implemented = ["test_noargs"]
+
+
+class StrIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, str)"
+    not_implemented = ["test_noargs"]
+
+
+class TupleIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, tuple)"
+    not_implemented = ["test_noargs"]
+
+
+class TypeIsinstanceFunctionTest(BuiltinFunctionTestCase, TranspileTestCase):
+    function = "lambda a: isinstance(a, type)"
+    not_implemented = ["test_noargs"]
+
+
 class BuiltinIsinstanceFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTestCase):
     function = "isinstance"
 
     not_implemented = [
         "test_bool_class",
-        "test_str_class",
     ]

--- a/tests/builtins/test_type.py
+++ b/tests/builtins/test_type.py
@@ -10,7 +10,6 @@ class TypeTests(TranspileTestCase):
 class BuiltinTypeFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "type"
 
-    @unittest.expectedFailure
     def test_type_equality(self):
         self.assertCodeExecution("""
         print(type(123))

--- a/tests/modules/test_stdlib.py
+++ b/tests/modules/test_stdlib.py
@@ -32,7 +32,6 @@ class StdlibTests(TranspileTestCase):
     def test_copyreg(self):
         _test_module(self, "copyreg")
 
-    @unittest.expectedFailure  # Token uses 'isinstance(value, int)' but 'int' isn't actually a type currently.
     def test_token(self):
         # our version doesn't quite sync up
         self.assertCodeExecution("""

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -7,7 +7,6 @@ import unittest
 
 class TimeTests(TranspileTestCase):
 
-    @unittest.expectedFailure
     def test_time(self):
         self.assertCodeExecution("""
             import time


### PR DESCRIPTION
This updates all the builtin functions for types (except memoryview) to point to the types themselves, and moves the custom creation logic to `<type>.__call__`.

`type(1) == int` is now true
`isinstance(1, int)` is now true

I've manually added test classes to test_isinstance.py for each of these types against all the sample data. I'd like to add types as a new category of sample data and have the two arg isinstance test class cover these, but it introduces a whole mess of new test failures so it seemed cleaner to break that out to its own change.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
