### PR TITLE
Add tox.ini to run tests in multiple python versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ npm-debug.log
 # Py.test
 .cache
 
+# Tox
+.tox
+
 # local environment configuration
 .env
 /.cache-loader/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CONTRIBUTING.md
 include AUTHORS
 include LICENSE
 include Makefile
+include package.json
 include requirements*.txt
 include run_in_batavia.js
 include compile_module.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py34, py35, py36
+
+[testenv]
+whitelist_externals = npm
+setenv = PRECOMPILE = false
+deps =
+    pytest
+    pytest-xdist
+commands =
+    npm install
+    {toxinidir}/node_modules/.bin/webpack
+    pytest -n auto --maxfail=20 --ignore node_modules --ignore .tox


### PR DESCRIPTION
I have tested checking out batavia in a clean directory and running tox. It runs the tests in all three python versions. It still requires having a new version of node and npm installed before.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
