### PR TITLE
Add timeout to Python and JS test execution.

### DIFF
--- a/tests/js_harness.js
+++ b/tests/js_harness.js
@@ -42,7 +42,7 @@ let child = cp.fork('tests/test_worker')
  */
 function _execute_with_batavia(code, callback) {
     const reportTimeout = setTimeout(() => {
-        child.kill()
+        child.kill('SIGHUP')
         callback('********** JAVASCRIPT EXECUTION TIMED OUT **********')
         child = cp.fork('tests/test_worker')
     }, FOUR_SECOND_TIMEOUT)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,14 @@ import unittest
 from .utils import adjust, JSCleaner, PYCleaner, TranspileTestCase
 
 
+class TimeoutTests(TranspileTestCase):
+    def test_infinite_loop(self):
+        self.assertCodeExecution("""
+            while True:
+              pass
+        """, substitutions={'RUNNER': ['PYTHON', 'JAVASCRIPT']})
+
+
 class AdjustTests(unittest.TestCase):
     def assertEqualOutput(self, actual, expected):
         self.assertEqual(adjust(actual), adjust(expected))

--- a/tests/test_worker.js
+++ b/tests/test_worker.js
@@ -1,0 +1,35 @@
+const vm = require('vm')
+
+process.on('message', function(message) {
+    const batavia = require(message.bataviaSource)
+
+    // This cache is global, instead of per batavia.VirtualMachine instance...
+    batavia.modules.sys.modules = {}
+
+    process.send(_capture_stdout(() => {
+        const m = require('module')
+        vm.runInThisContext(m.wrap(message.code))(exports, require, module, __filename, __dirname)
+    }))
+})
+
+/**
+ * Run a function, capturing stdout and returning everything written to it.
+ *
+ * @param {function()} f The function to run.
+ * @return {string}
+ * @private
+ */
+function _capture_stdout(f) {
+    let output = ''
+    const old_write = process.stdout.write
+
+    process.stdout.write = (str, encoding, fd) => {
+        output += str
+    }
+
+    f()
+
+    process.stdout.write = old_write
+
+    return output
+}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -206,7 +206,12 @@ def runAsPython(test_dir, main_code, extra_code=None, run_in_function=False, arg
         cwd=test_dir,
         env=env_copy,
     )
-    out = proc.communicate()
+    try:
+        out = proc.communicate(timeout=4)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        return "********** PYTHON EXECUTION TIMED OUT **********"
 
     return out[0].decode('utf8')
 


### PR DESCRIPTION
Added four second timeouts to both Python and JS test cases (and an infinite loop test case to test that it keeps us safe.)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
