### PR TITLE
Prevent unintentional exceptions constituting a passing test.

### DIFF
--- a/tests/builtins/test_abs.py
+++ b/tests/builtins/test_abs.py
@@ -9,7 +9,11 @@ class AbsTests(TranspileTestCase):
 
 
             x = NotAbsLike()
-            print(abs(x))
+            try:
+                print(abs(x))
+            except TypeError as e:
+                print(e)
+                print('Done.')
             """, run_in_function=False)
 
 

--- a/tests/builtins/test_all.py
+++ b/tests/builtins/test_all.py
@@ -16,7 +16,12 @@ class AllTests(TranspileTestCase):
         self.assertCodeExecution("print(all([]))")
 
     def test_all_typeerror(self):
-        self.assertCodeExecution("print(all(None))")
+        self.assertCodeExecution("""
+            try:
+                print(all(None))
+            except TypeError:
+                print("Done.")
+        """)
 
 
 class BuiltinAllFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_any.py
+++ b/tests/builtins/test_any.py
@@ -16,7 +16,13 @@ class AnyTests(TranspileTestCase):
         self.assertCodeExecution("print(any([]))")
 
     def test_any_typeerror(self):
-        self.assertCodeExecution("print(any(None))")
+        self.assertCodeExecution("""
+            try:
+                print(any(None))
+            except TypeError as e:
+                print(e)
+                print('Done.')
+        """)
 
 
 class BuiltinAnyFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_bin.py
+++ b/tests/builtins/test_bin.py
@@ -11,7 +11,11 @@ class BinTests(TranspileTestCase):
                     return self.val
 
             x = IntLike(5)
-            print(bin(x))
+            try:
+                print(bin(x))
+            except TypeError as e:
+                print(e)
+                print('Done.')
             """, run_in_function=False)
 
 

--- a/tests/builtins/test_bool.py
+++ b/tests/builtins/test_bool.py
@@ -55,11 +55,30 @@ class BoolTests(TranspileTestCase):
                 def __bool__(self):
                     return self.val
 
-            print(bool(BoolHate("zero")))
-            print(bool(BoolHate([1, 2, 3])))
-            print(bool(BoolHate({1: 2})))
-            print(bool(BoolHate(1.2)))
-            print(bool(BoolHate("👿")))
+            try:
+                print(bool(BoolHate("zero")))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(BoolHate([1, 2, 3])))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(BoolHate({1: 2})))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(BoolHate(1.2)))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(BoolHate("👿")))
+            except TypeError as e:
+                print(e)
         """)
 
     def test_len_malicious(self):
@@ -71,11 +90,30 @@ class BoolTests(TranspileTestCase):
                 def __len__(self):
                     return self.val
 
-            print(bool(LenHate("zero")))
-            print(bool(LenHate([1, 2, 3])))
-            print(bool(LenHate({1: 2})))
-            print(bool(LenHate(1.2)))
-            print(bool(BoolHate("👿")))
+            try:
+                print(bool(LenHate("zero")))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(LenHate([1, 2, 3])))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(LenHate({1: 2})))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(LenHate(1.2)))
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(bool(LenHate("👿")))
+            except TypeError as e:
+                print(e)
         """)
 
 

--- a/tests/builtins/test_next.py
+++ b/tests/builtins/test_next.py
@@ -23,11 +23,13 @@ class NextTests(TranspileTestCase):
             print(next(i, 0))
         """)
 
-    @expectedFailure
     def test_next_exhausted_without_default(self):
         self.assertCodeExecution("""
+        try:
             i = iter([])
             print(next(i))
+        except StopIteration:
+            print("Done.")
         """)
 
 

--- a/tests/builtins/test_pow.py
+++ b/tests/builtins/test_pow.py
@@ -16,7 +16,11 @@ class PowTests(TranspileTestCase):
             x = 3
             y = -4
             z = 5
-            print(pow(x, y, z))
+            try:
+                print(pow(x, y, z))
+            except (ValueError, TypeError) as e:
+                print(e)
+                print('Done.')
         """)
 
     def test_int_neg_y_neg_z(self):
@@ -24,7 +28,11 @@ class PowTests(TranspileTestCase):
             x = 3
             y = -4
             z = -5
-            print(pow(x, y, z))
+            try:
+                print(pow(x, y, z))
+            except (ValueError, TypeError) as e:
+                print(e)
+                print('Done.')
         """)
 
     def test_int_y_zero_z_one(self):
@@ -48,7 +56,11 @@ class PowTests(TranspileTestCase):
             x = 3.3
             y = 4
             z = 5
-            print(pow(x, y, z))
+            try:
+                print(pow(x, y, z))
+            except TypeError as e:
+                print(e)
+                print('Done.')
             """)
 
     def test_float_y_with_z(self):
@@ -56,7 +68,11 @@ class PowTests(TranspileTestCase):
             x = 3
             y = 4.4
             z = 5
-            print(pow(x, y, z))
+            try:
+                print(pow(x, y, z))
+            except TypeError as e:
+                print(e)
+                print('Done.')
             """)
 
     def test_float(self):
@@ -64,7 +80,11 @@ class PowTests(TranspileTestCase):
             x = 3.3
             y = 4.4
             z = 5.5
-            print(pow(x, y, z))
+            try:
+                print(pow(x, y, z))
+            except TypeError as e:
+                print(e)
+                print('Done.')
         """)
 
     def test_float_neg_y_with_z(self):
@@ -72,7 +92,11 @@ class PowTests(TranspileTestCase):
             x = 3.3
             y = -4.4
             z = 5.5
-            print(pow(x, y, z))
+            try:
+                print(pow(x, y, z))
+            except TypeError as e:
+                print(e)
+                print('Done.')
         """)
 
     def test_huge_y(self):

--- a/tests/builtins/test_slice.py
+++ b/tests/builtins/test_slice.py
@@ -6,19 +6,27 @@ class SliceTests(TranspileTestCase):
     def test_slice_args(self):
         # no args
         self.assertCodeExecution("""
-            print("slice() = ", slice())
+            try:
+                print("slice() = ", slice())
+            except TypeError as e:
+                print(e)
+                print('Done')
         """)
 
         # too many args
         self.assertCodeExecution("""
-            print("slice(1, 2, 3, 4) = ", slice(1, 2, 3, 4))
+            try:
+                print("slice(1, 2, 3, 4) = ", slice(1, 2, 3, 4))
+            except TypeError as e:
+                print(e)
+                print('Done')
         """)
 
         # valid number of args
         self.assertCodeExecution("""
             print("slice(1) = ", slice(1, 2))
             print("slice(1, 2) = ", slice(1, 2, 3))
-            print("slice(1, 2, 3, 4) = ", slice(1, 2, 3))
+            print("slice(1, 2, 3) = ", slice(1, 2, 3))
         """)
 
     def test_slice_arg_types(self):

--- a/tests/datatypes/test_NoneType.py
+++ b/tests/datatypes/test_NoneType.py
@@ -6,14 +6,20 @@ class NoneTypeTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = None
-            x.thing = 42
+            try:
+                x.thing = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = None
-            y = x.thing
+            try:
+                y = x.thing
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -6,14 +6,20 @@ class BoolTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = True
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = True
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -9,14 +9,20 @@ class BytesTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = b'hello, world'
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = b'hello, world'
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -9,14 +9,20 @@ class ComplexTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = b'hello, world'
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = b'hello, world'
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -10,14 +10,20 @@ class DictTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = {}
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = {}
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
@@ -42,7 +48,11 @@ class DictTests(TranspileTestCase):
         # keys with the same string representation
         self.assertCodeExecution("""
             x = {1: 2, '1': 1}
-            print(sorted(x.items()))
+            try:
+                print(sorted(x.items()))
+            except TypeError as e:
+                print(e)
+            print('Done.')
         """, substitutions=subst)
 
     def test_getitem(self):
@@ -60,7 +70,10 @@ class DictTests(TranspileTestCase):
             x = {'a': 1, 'b': 2}
             print('c' in x)
             print('c' not in x)
-            print(x['c'])
+            try:
+                print(x['c'])
+            except KeyError as e:
+                print(e)
             """, run_in_function=False)
 
         # Override key
@@ -125,7 +138,11 @@ class DictTests(TranspileTestCase):
     def test_builtin_non_2_tuples(self):
         # One of the elements isn't a 2-tuple
         self.assertCodeExecution("""
-            x = dict([('a', 1), ('b', 2, False)])
+            try:
+                x = dict([('a', 1), ('b', 2, False)])
+            except ValueError as e:
+                print(e)
+            print('Done.')
             """, run_in_function=False)
 
     def test_print_dict(self):
@@ -171,7 +188,11 @@ class DictTests(TranspileTestCase):
     def test_builtin_non_sequence(self):
         # One of the elements isn't a sequence
         self.assertCodeExecution("""
-            x = dict([('a', 1), False, ('b', 2)])
+            try:
+                x = dict([('a', 1), False, ('b', 2)])
+            except TypeError as e:
+                print(e)
+            print('Done.')
             """, run_in_function=False)
 
     def test_pop_success(self):
@@ -190,12 +211,20 @@ class DictTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             d = {'a': 1}
-            d.pop('b')
+            try:
+                d.pop('b')
+            except KeyError as e:
+                print(e)
+            print('Done')
         """)
 
         self.assertCodeExecution("""
             d = {}
-            d.pop(1, 2, 3)
+            try:
+                d.pop(1, 2, 3)
+            except TypeError as e:
+                print(e)
+            print('Done.')
         """)
 
     def test_popitem_success(self):
@@ -216,12 +245,20 @@ class DictTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             d = {}
-            d.popitem(1)
+            try:
+                d.popitem(1)
+            except TypeError as e:
+                print(e)
+            print('Done.')
         """)
 
         self.assertCodeExecution("""
             d = {}
-            d.popitem()
+            try:
+                d.popitem()
+            except KeyError as e:
+                print(e)
+            print('Done.')
         """)
 
     def test_setdefault_success(self):
@@ -240,7 +277,11 @@ class DictTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             d = {}
-            d.setdefault()
+            try:
+                d.setdefault()
+            except TypeError as e:
+                print(e)
+            print('Done.')
         """)
 
     def test_fromkeys_success(self):
@@ -259,7 +300,11 @@ class DictTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             d = {}
-            print(d.fromkeys([], None, None))
+            try:
+                print(d.fromkeys([], None, None))
+            except TypeError as e:
+                print(e)
+            print('Done.')
         """)
 
     def test_len(self):

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -9,14 +9,20 @@ class FloatTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = 3.14159
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = 3.14159
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -6,20 +6,30 @@ class IntTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = 37
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = 37
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_invalid_literal(self):
         self.assertCodeExecution("""
-            int('q', 16)
+            try:
+                int('q', 16)
+            except ValueError as e:
+                print(e)
+            print('Done.')
             """, run_in_function=False)
 
     def test_addition_promotes_past_32bits(self):

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -43,14 +43,20 @@ class ListTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = [1, 2, 3]
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = [1, 2, 3]
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
@@ -114,13 +120,19 @@ class ListTests(TranspileTestCase):
         # Positive index out of range
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
-            print(x[10])
+            try:
+                print(x[10])
+            except IndexError as e:
+                print(e)
             """)
 
         # Negative index out of range
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
-            print(x[-10])
+            try:
+                print(x[-10])
+            except IndexError as e:
+                print(e)
             """)
 
     def test_index(self):
@@ -176,7 +188,11 @@ class ListTests(TranspileTestCase):
         # Slice with step 0 (error)
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
-            print(x[::0])
+            try:
+                print(x[::0])
+            except ValueError as e:
+                print(e)
+            print('Done.')
             """)
 
         # Slice with revese step
@@ -191,7 +207,7 @@ class ListTests(TranspileTestCase):
             print(x[-5:-1:-1])
             """)
 
-        # Slice -1 start with revese step
+        # Slice -1 start with reverse step
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
             print(x[-1:0:-1])
@@ -274,18 +290,27 @@ class ListTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             l = []
-            l.insert()
+            try:
+                l.insert()
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             l = []
-            l.insert("0", 1)
+            try:
+                l.insert("0", 1)
+            except TypeError as e:
+                print(e)
             print(l)
         """)
 
         self.assertCodeExecution("""
             l = []
-            l.insert(1.0, 1)
+            try:
+                l.insert(1.0, 1)
+            except TypeError as e:
+                print(e)
         """)
 
     @unittest.expectedFailure
@@ -315,12 +340,18 @@ class ListTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             l = []
-            l.remove(1)
+            try:
+                l.remove(1)
+            except ValueError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             l = [1]
-            l.remove()
+            try:
+                l.remove()
+            except TypeError as e:
+                print(e)
         """)
 
     def test_pop_success(self):
@@ -344,18 +375,27 @@ class ListTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             l = [1, 2]
-            l.pop(2)
+            try:
+                l.pop(2)
+            except IndexError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             l = []
-            l.pop(1, 2)
-        """)
+            try:
+                l.pop(1, 2)
+            except TypeError as e:
+                print(e)
+            """)
 
         self.assertCodeExecution("""
             l = [1]
-            l.pop("0")
-        """)
+            try:
+                l.pop("0")
+            except TypeError as e:
+                print(e)
+            """)
 
     @unittest.expectedFailure
     def test_pop_subclass_index(self):
@@ -384,7 +424,10 @@ class ListTests(TranspileTestCase):
 
         self.assertCodeExecution("""
             l = ["one", "two", 3]
-            l.clear("invalid")
+            try:
+                l.clear("invalid")
+            except TypeError as e:
+                print(e)
             print(l)
         """)
 

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -27,7 +27,11 @@ class RangeTests(TranspileTestCase):
             print("x[1] =", x[1])
             print("x[3] =", x[3])
             print("x[-1] =", x[-1])
-            print("x[5] =", x[5])
+            try:
+                print("x[5] =", x[5])
+            except IndexError as e:
+                print(e)
+            print('Done.')
             """)
 
     def test_start_not_zero(self):
@@ -37,7 +41,10 @@ class RangeTests(TranspileTestCase):
             print("x[1] =", x[1])
             print("x[3] =", x[3])
             print("x[-1] =", x[-1])
-            print("x[5] =", x[5])
+            try:
+                print("x[5] =", x[5])
+            except IndexError as e:
+                print(e)
             """)
 
     def test_step(self):
@@ -45,9 +52,15 @@ class RangeTests(TranspileTestCase):
             x = range(0, 5, 2)
             print("x[0] =", x[0])
             print("x[1] =", x[1])
-            print("x[3] =", x[3])
+            try:
+                print("x[3] =", x[3])
+            except IndexError as e:
+                print(e)
             print("x[-1] =", x[-1])
-            print("x[5] =", x[5])
+            try:
+                print("x[5] =", x[5])
+            except IndexError as e:
+                print(e)
             """)
 
     def test_step_negative(self):

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -14,14 +14,20 @@ class SetTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = {1, 2, 3}
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = {1, 2, 3}
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
@@ -60,7 +66,10 @@ class SetTests(TranspileTestCase):
         # Simple non-existent key
         self.assertCodeExecution("""
             x = {'a', 'b'}
-            print('c' in x)
+            try:
+                print('c' in x)
+            except KeyError as e:
+                print(e)
             """)
 
     def test_iter(self):

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -25,31 +25,49 @@ class SliceTests(TranspileTestCase):
         # step 0
         self.assertCodeExecution("""
             x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            print("x[2::0] = ", x[2::0])
+            try:
+                print("x[2::0] = ", x[2::0])
+            except ValueError as e:
+                print(e)
         """)
         # start, stop and step must be int
         self.assertCodeExecution("""
             x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            print("x[::2.5] = ", x[::2.5])
+            try:
+                print("x[::2.5] = ", x[::2.5])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            print("x[::'a'] = ", x[::'a'])
+            try:
+                print("x[::'a'] = ", x[::'a'])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            print("x['a':2] = ", x['a':2])
+            try:
+                print("x['a':2] = ", x['a':2])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            print("x[1:'a':7] = ", x[1:'a':7])
+            try:
+                print("x[1:'a':7] = ", x[1:'a':7])
+            except TypeError as e:
+                print(e)
         """)
         self.assertCodeExecution("""
             x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            print("x[1:None] = ", x[1:None])
+            try:
+                print("x[1:None] = ", x[1:None])
+            except TypeError as e:
+                print(e)
         """)
 
     def test_slice_range(self):
@@ -74,31 +92,49 @@ class SliceTests(TranspileTestCase):
         # step 0
         self.assertCodeExecution("""
             x = range(0, 10)
-            print("x[2::0] = ", x[2::0])
+            try:
+                print("x[2::0] = ", x[2::0])
+            except ValueError as e:
+                print(e)
         """)
         # start, stop and step must be int
         self.assertCodeExecution("""
             x = range(0, 10)
-            print("x[::2.5] = ", x[::2.5])
+            try:
+                print("x[::2.5] = ", x[::2.5])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = range(0, 10)
-            print("x[::'a'] = ", x[::'a'])
+            try:
+                print("x[::'a'] = ", x[::'a'])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = range(0, 10)
-            print("x['a':2] = ", x['a':2])
+            try:
+                print("x['a':2] = ", x['a':2])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = range(0, 10)
-            print("x[1:'a':7] = ", x[1:'a':7])
+            try:
+                print("x[1:'a':7] = ", x[1:'a':7])
+            except TypeError as e:
+                print(e)
         """)
         self.assertCodeExecution("""
             x = range(0, 10)
-            print("x[1:None] = ", x[1:None])
+            try:
+                print("x[1:None] = ", x[1:None])
+            except TypeError as e:
+                print(e)
         """)
 
     def test_slice_string(self):
@@ -123,31 +159,49 @@ class SliceTests(TranspileTestCase):
         # step 0
         self.assertCodeExecution("""
             x = "0123456789a"
-            print("x[2::0] = ", x[2::0])
+            try:
+                print("x[2::0] = ", x[2::0])
+            except ValueError as e:
+                print(e)
         """)
         # start, stop and step must be int
         self.assertCodeExecution("""
             x = "0123456789a"
-            print("x[::2.5] = ", x[::2.5])
+            try:
+                print("x[::2.5] = ", x[::2.5])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = "0123456789a"
-            print("x[::'a'] = ", x[::'a'])
+            try:
+                print("x[::'a'] = ", x[::'a'])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = "0123456789a"
-            print("x['a':2] = ", x['a':2])
+            try:
+                print("x['a':2] = ", x['a':2])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = "0123456789a"
-            print("x[1:'a':7] = ", x[1:'a':7])
+            try:
+                print("x[1:'a':7] = ", x[1:'a':7])
+            except TypeError as e:
+                print(e)
         """)
         self.assertCodeExecution("""
             x = "0123456789a"
-            print("x[1:None] = ", x[1:None])
+            try:
+                print("x[1:None] = ", x[1:None])
+            except TypeError as e:
+                print(e)
         """)
 
     def test_slice_tuple(self):
@@ -171,31 +225,49 @@ class SliceTests(TranspileTestCase):
         # step 0
         self.assertCodeExecution("""
             x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-            print("x[2::0] = ", x[2::0])
+            try:
+                print("x[2::0] = ", x[2::0])
+            except ValueError as e:
+                print(e)
         """)
         # start, stop and step must be int
         self.assertCodeExecution("""
             x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-            print("x[::2.5] = ", x[::2.5])
+            try:
+                print("x[::2.5] = ", x[::2.5])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-            print("x[::'a'] = ", x[::'a'])
+            try:
+                print("x[::'a'] = ", x[::'a'])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-            print("x['a':2] = ", x['a':2])
+            try:
+                print("x['a':2] = ", x['a':2])
+            except TypeError as e:
+                print(e)
         """)
 
         self.assertCodeExecution("""
             x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-            print("x[1:'a':7] = ", x[1:'a':7])
+            try:
+                print("x[1:'a':7] = ", x[1:'a':7])
+            except TypeError as e:
+                print(e)
         """)
         self.assertCodeExecution("""
             x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-            print("x[1:None] = ", x[1:None])
+            try:
+                print("x[1:None] = ", x[1:None])
+            except TypeError as e:
+                print(e)
         """)
 
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -26,14 +26,20 @@ class StrTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = "Hello, world"
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = "Hello, world"
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
@@ -53,13 +59,19 @@ class StrTests(TranspileTestCase):
         # Positive index out of range
         self.assertCodeExecution("""
             x = 'abcde'
-            print(x[10])
+            try:
+                print(x[10])
+            except IndexError as e:
+                print(e)
             """)
 
         # Negative index out of range
         self.assertCodeExecution("""
             x = 'abcde'
-            print(x[-10])
+            try:
+                print(x[-10])
+            except IndexError as e:
+                print(e)
             """)
 
     def test_slice(self):
@@ -90,7 +102,10 @@ class StrTests(TranspileTestCase):
         # Slice with step 0 (error)
         self.assertCodeExecution("""
             x = 'abcde'
-            print(x[::0])
+            try:
+                print(x[::0])
+            except ValueError as e:
+                print(e)
             """)
 
         # Slice with revese step
@@ -695,7 +710,10 @@ class StrTests(TranspileTestCase):
         print("abc".index("b"))
         print("abc".index("c"))
         print("abc".index("bc"))
-        print("abc".index("d"))
+        try:
+            print("abc".index("d"))
+        except ValueError as e:
+            print(e)
         """)
 
     def test_contains_escapes_regular_expressions(self):
@@ -909,7 +927,10 @@ class FormatTests(TranspileTestCase):
                 print(">>> '%s %%' % 'spam'")
                 print('%s %%' % 'spam')
                 print(">>> '%%5.5d' % 5")
-                print('%%5.5d' % 5)
+                try:
+                    print('%%5.5d' % 5)
+                except TypeError as e:
+                    print(e)
                 print(">>> '%s %% %s' % ('spam', 'beans')")
                 print('%s %% %s' % ('spam', 'beans'))
                 """)
@@ -1004,13 +1025,14 @@ class FormatTests(TranspileTestCase):
                 print('Done.')
                 """)
 
-            self.assertCodeExecution(test, js_cleaner = js_cleaner, py_cleaner = py_cleaner)
+            self.assertCodeExecution(test, js_cleaner=js_cleaner, py_cleaner=py_cleaner)
 
+        @unittest.expectedFailure
         @transforms(
-            js_bool = False,
-            decimal = False,
-            float_exp = False,
-            memory_ref = False
+            js_bool=False,
+            decimal=False,
+            float_exp=False,
+            memory_ref=False
         )
         def test_with_kwargs(self, js_cleaner, py_cleaner):
 
@@ -1034,61 +1056,58 @@ class FormatTests(TranspileTestCase):
 
             tests = adjust("""
                 print(">>> 'format this: %(arg)s' % ({'arg':'spam'}, {'arg2':'eggs'})")
-                print('format this: %(arg)s' % ({'arg':'spam'}, {'arg2':'eggs'}))
+                try:
+                    print('format this: %(arg)s' % ({'arg':'spam'}, {'arg2':'eggs'}))
+                except TypeError as e:
+                    print(e)
                 print('Done.')
                 """)
 
-            self.assertCodeExecution(tests, js_cleaner = js_cleaner, py_cleaner = py_cleaner)
+            self.assertCodeExecution(tests, js_cleaner=js_cleaner, py_cleaner=py_cleaner)
 
         @transforms(
-            js_bool = False,
-            decimal = False,
-            float_exp = False,
-            memory_ref = False
-        )
-        def test_with_kwargs(self, js_cleaner, py_cleaner):
-
-            tests = adjust("""
-                print(">>> 'format this: %(arg' % {'arg':'spam'}")
-                print('format this: %(arg' % {'arg':'spam'})
-                print('Done.')
-                """)
-
-            self.assertCodeExecution(tests, js_cleaner = js_cleaner, py_cleaner = py_cleaner)
-
-        @transforms(
-            js_bool = False,
-            decimal = False,
-            float_exp = False,
-            memory_ref = False
+            js_bool=False,
+            decimal=False,
+            float_exp=False,
+            memory_ref=False
         )
         def test_wildcard_with_kwargs(self, js_cleaner, py_cleaner):
 
             tests = adjust("""
                 print(">>> '%*(spam)s' % {'spam': 'eggs'}")
-                print('%*(spam)s' % {'spam': 'eggs'})
+                try:
+                    print('%*(spam)s' % {'spam': 'eggs'})
+                except TypeError as e:
+                    print(e)
                 print('Done.')
                 """)
 
-            self.assertCodeExecution(tests, js_cleaner = js_cleaner, py_cleaner = py_cleaner)
+            self.assertCodeExecution(tests, js_cleaner=js_cleaner, py_cleaner=py_cleaner)
 
         @transforms(
-            js_bool = False,
-            decimal = False,
-            float_exp = False,
-            memory_ref = False
+            js_bool=False,
+            decimal=False,
+            float_exp=False,
+            memory_ref=False
         )
         def test_kwargs_missing_key(self, js_cleaner, py_cleaner):
 
             tests = adjust("""
                 print(">>> 'format this: %(beans)s' % {'spam':'eggs'}")
-                print('format this: %(beans)s' % {'spam':'eggs'})
+                try:
+                    print('format this: %(beans)s' % {'spam':'eggs'})
+                except KeyError as e:
+                    print(e)
                 print(">>> 'format this: %(1)s' % {'spam':'eggs'}")
-                print('format this: %(1)s' % {'spam':'eggs'})
+                try:
+                    print('format this: %(1)s' % {'spam':'eggs'})
+                except KeyError as e:
+                    print(e)
                 print('Done.')
                 """)
 
-            self.assertCodeExecution(tests, js_cleaner = js_cleaner, py_cleaner = py_cleaner)
+            self.assertCodeExecution(tests, js_cleaner=js_cleaner, py_cleaner=py_cleaner)
+
 
 class NewStyleFormatTests(TranspileTestCase):
     """
@@ -1109,7 +1128,10 @@ class NewStyleFormatTests(TranspileTestCase):
         # should raise an index error
         test_str = adjust("""
         print(">>> 'one arg: {} {} great!'.format('really')")
-        print('one arg: {} {} great!'.format('really'))
+        try:
+            print('one arg: {} {} great!'.format('really'))
+        except IndexError as e:
+            print(e)
         """)
 
         self.assertCodeExecution(test_str)
@@ -1127,7 +1149,10 @@ class NewStyleFormatTests(TranspileTestCase):
     def test_index_out_of_range(self):
         test_str = adjust("""
         print(">>> 'Some numbers: {0} {1} {5}'.format('one', 'two', 'three')")
-        print('Some numbers: {0} {1} {5}'.format('one', 'two', 'three'))
+        try:
+            print('Some numbers: {0} {1} {5}'.format('one', 'two', 'three'))
+        except IndexError as e:
+            print(e)
         """)
 
         self.assertCodeExecution(test_str)
@@ -1135,7 +1160,10 @@ class NewStyleFormatTests(TranspileTestCase):
     def test_kwargs(self):
         test_str = adjust("""
         print(">>> '{food}! Lovely {food}! Lovely {food}!'.format(food='spam', other='eggs')")
-        print('{food}! Lovely {food}! Lovely {food}!'.format(food='spam', other='eggs'))
+        try:
+            print('{food}! Lovely {food}! Lovely {food}!'.format(food='spam', other='eggs'))
+        except KeyError as e:
+            print(e)
         """)
 
         self.assertCodeExecution(test_str)
@@ -1143,7 +1171,10 @@ class NewStyleFormatTests(TranspileTestCase):
     def test_kwargs_key_error(self):
         test_str = adjust("""
         print(">>> '{food}! Lovely {food}! Lovely {food}!'.format(other='eggs')")
-        print('{food}! Lovely {food}! Lovely {food}!'.format(other='eggs'))
+        try:
+            print('{food}! Lovely {food}! Lovely {food}!'.format(other='eggs'))
+        except KeyError as e:
+            print(e)
         """)
 
         self.assertCodeExecution(test_str)
@@ -1176,25 +1207,32 @@ class NewStyleFormatTests(TranspileTestCase):
         test_str = adjust("""
         coord = (3, 5)
         print(">>> 'X: {0[]}}'.format(coord)")
-        print('X: {0[]}'.format(coord))
+        try:
+            print('X: {0[]}'.format(coord))
+        except ValueError as e:
+            print(e)
         print(">>> 'X: {0[}}'.format(coord)")
-        print('X: {0[}'.format(coord))
+        try:
+            print('X: {0[}'.format(coord))
+        except ValueError as e:
+            print(e)
         """)
         self.assertCodeExecution(test_str)
 
+    @unittest.expectedFailure
     def test_name_with__getattr__(self):
         """
         name calls attribute on passed argument
         """
-
 
         test_str = adjust("""
         class Actor():
             name = 'John Cleese'
 
         print(">>> '{a.name}'.format(a=Actor())")
-        print('{a.name}'.format(a=Actor())')
+        print('{a.name}'.format(a=Actor()))
         """)
+        self.assertCodeExecution(test_str)
 
     def test__getattr__bad_formatting(self):
         """
@@ -1203,8 +1241,13 @@ class NewStyleFormatTests(TranspileTestCase):
         test_str = adjust("""
 
         print(">>> '{food.}'.format(food='spam')")
-        print('{food.}'.format(food='spam'))
+        try:
+            print('{food.}'.format(food='spam'))
+        except ValueError as e:
+            print(e)
         """)
+        self.assertCodeExecution(test_str)
+
     # conversion flags
     def test_conversion_flags(self):
         conversion_flags = ('!a', '!s', '!r', '!', '!ss', '!g')
@@ -1214,7 +1257,10 @@ class NewStyleFormatTests(TranspileTestCase):
                 adjust(
                     """
                     print(">>> 'one arg: {{{flag}:}}'.format('great')")
-                    print('one arg: {{{flag}:}}'.format('great'))
+                    try:
+                        print('one arg: {{{flag}:}}'.format('great'))
+                    except ValueError as e:
+                        print(e)
                     """.format(flag=flag)
                 ) for flag in conversion_flags
             ]
@@ -1222,23 +1268,34 @@ class NewStyleFormatTests(TranspileTestCase):
 
         self.assertCodeExecution(test_str)
 
+    @unittest.expectedFailure
     def test_fills(self):
-        fills = ('*', '**', '{', '}') # only one character, no curly braces
-        test_str = ''.join(
-            [
-                adjust(
-                    """
-                    print(">>> 'one arg: {{:{fill}<10}}'.format('great')")
-                    print('one arg: {{:{fill}<10}}'.format('great'))
-                    """.format(fill=fill)
-                ) for fill in fills
-            ]
-        )
+        """only one character, no curly braces."""
+
+        test_str = """
+          print(">>> 'one arg: {:*<10}'.format('great')")
+          print('one arg: {:*<10}'.format('great'))
+          print(">>> 'one arg: {:**<10}'.format('great')")
+          try:
+              print('one arg: {:**<10}'.format('great'))
+          except ValueError as e:
+              print(e)
+          print(">>> 'one arg: {:{<10}'.format('great')")
+          try:
+              print('one arg: {:{<10}'.format('great'))
+          except ValueError as e:
+              print(e)
+          print(">>> 'one arg: {:}<10}'.format('great')")
+          try:
+              print('one arg: {:}<10}'.format('great'))
+          except ValueError as e:
+              print(e)
+        """
 
         self.assertCodeExecution(test_str)
 
     def test_alignments(self):
-        alignments = ['<', '^', '>', '=']
+        alignments = ['<', '^', '>']
         test_str = ''.join(
             [
                 adjust(
@@ -1251,14 +1308,37 @@ class NewStyleFormatTests(TranspileTestCase):
                 ) for align in alignments
             ]
         )
-
         self.assertCodeExecution(test_str)
+
+    @unittest.expectedFailure
+    def test_sign_alignment(self):
+        self.assertCodeExecution("""
+                    print(">>> 'one arg: {:=10}'.format(12)")
+                    print('one arg: {:=10}'.format(12))
+                    print(">>> 'one arg: {:*=10}'.format(12)")
+                    print('one arg: {:*=10}'.format(12))
+                    print(">>> 'one arg: {:*=+10}'.format(12)")
+                    print('one arg: {:*=+10}'.format(12))
+                    print(">>> 'one arg: {:*=-10}'.format(12)")
+                    print('one arg: {:*=-10}'.format(12))
+                    print(">>> 'one arg: {:=10}'.format(-12)")
+                    print('one arg: {:=10}'.format(-12))
+                    print(">>> 'one arg: {:*=10}'.format(-12)")
+                    print('one arg: {:*=10}'.format(-12))
+                    print(">>> 'one arg: {:*=+10}'.format(-12)")
+                    print('one arg: {:*=+10}'.format(-12))
+                    print(">>> 'one arg: {:*=-10}'.format(-12)")
+                    print('one arg: {:*=-10}'.format(-12))
+                    """)
 
     def test_fill_no_alignment(self):
 
         test_str = adjust("""
         print(">>> 'one arg: {:*10}'.format('great')")
-        print('one arg: {:*10}'.format('great'))
+        try:
+            print('one arg: {:*10}'.format('great'))
+        except ValueError as e:
+            print(e)
         """)
 
         self.assertCodeExecution(test_str)
@@ -1288,26 +1368,33 @@ class NewStyleFormatTests(TranspileTestCase):
 
         test_str = adjust("""
         print(">>> 'one arg: {:+}'.format('great')")
-        print('one arg: {:+}'.format('great'))
+        try:
+            print('one arg: {:+}'.format('great'))
+        except ValueError as e:
+            print(e)
         """)
 
         self.assertCodeExecution(test_str)
 
+    @transforms(decimal=False, )
+    def test_comma_grouping(self, js_cleaner, py_cleaner):
+        test_str = """
+          print(">>> 'one arg:: {:,}'.format(5000)")
+          print('one arg:: {:,}'.format(5000))
+        """
+        self.assertCodeExecution(test_str, js_cleaner=js_cleaner,
+                                 py_cleaner=py_cleaner)
+
     @expected_failing_versions(['3.6'])
     @transforms(decimal=False,)
-    def test_groupings(self, js_cleaner, py_cleaner):
-        groupings = (',', '_')
-        test_str = ''.join(
-            [
-                adjust(
-                    """
-                    print(">>> 'one arg:: {{:{g}}}'.format(5000)")
-                    print('one arg:: {{:{g}}}'.format(5000))
-                    """.format(g=g)
-                ) for g in groupings
-            ]
-        )
-
+    def test_underscore_grouping(self, js_cleaner, py_cleaner):
+        test_str = """
+          print(">>> 'one arg:: {:_}'.format(5000)")
+          try:
+              print('one arg:: {:_}'.format(5000))
+          except ValueError as e:
+              print(e)
+        """
         self.assertCodeExecution(test_str, js_cleaner=js_cleaner,
                                  py_cleaner=py_cleaner)
 
@@ -1319,29 +1406,32 @@ class NewStyleFormatTests(TranspileTestCase):
 
         test_str = adjust("""
         print(">>> 'one arg: {:,}'.format('great')")
-        print('one arg: {:,}'.format('great'))
+        try:
+            print('one arg: {:,}'.format('great'))
+        except ValueError as e:
+            print(e)
         """)
 
         self.assertCodeExecution(test_str)
 
     def test_zero_padding(self):
-
-        test_str = adjust("""
-        print(">>> 'one arg: {:05}'.format(5)")
-        print('one arg: {:05}'.format(5))
-        print(">>> 'one arg: {:05}'.format('spam')")
-        print('one arg: {:05}'.format('spam'))
+        self.assertCodeExecution("""
+            print(">>> 'one arg: {:05}'.format(5)")
+            print('one arg: {:05}'.format(5))
+            print(">>> 'one arg: {:05}'.format('spam')")
+            try:
+                print('one arg: {:05}'.format('spam'))
+            except ValueError as e:
+                print(e)
         """)
 
-        self.assertCodeExecution(test_str)
-
+    @unittest.expectedFailure
     def test_conversion_types(self):
         """
         test all conversion types and their alternate forms
         """
         alternate = ('#', '')
-        types = ('b', 'c', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 's', 'x', 'X',
-                '%')
+        types = ('b', 'c', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 's', 'x', 'X', '%')
         args = ("'spam'", "'5'", 5, -5, 5.0, -5.0, 0.5, -0.5)
         combinations = product(alternate, types, args)
         test_str = ''.join(

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -9,14 +9,20 @@ class TupleTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
             x = (1, 2, 3)
-            x.attr = 42
+            try:
+                x.attr = 42
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
     def test_getattr(self):
         self.assertCodeExecution("""
             x = (1, 2, 3)
-            print(x.attr)
+            try:
+                print(x.attr)
+            except AttributeError as e:
+                print(e)
             print('Done.')
             """)
 
@@ -59,13 +65,19 @@ class TupleTests(TranspileTestCase):
         # Positive index out of range
         self.assertCodeExecution("""
             x = (1, 2, 3, 4, 5)
-            print(x[10])
+            try:
+                print(x[10])
+            except IndexError as e:
+                print(e)
             """)
 
         # Negative index out of range
         self.assertCodeExecution("""
             x = (1, 2, 3, 4, 5)
-            print(x[-10])
+            try:
+                print(x[-10])
+            except IndexError as e:
+                print(e)
             """)
 
     def test_count(self):
@@ -152,7 +164,10 @@ class TupleTests(TranspileTestCase):
         # Slice with step 0 (error)
         self.assertCodeExecution("""
             x = (1, 2, 3, 4, 5)
-            print(x[::0])
+            try:
+                print(x[::0])
+            except ValueError as e:
+                print(e)
             """)
 
         # Slice with revese step

--- a/tests/modules/test_random.py
+++ b/tests/modules/test_random.py
@@ -8,7 +8,7 @@ class RandomTests(TranspileTestCase):
 
             numbers = [1, 2, 3, 4, 5, 6, 7, 8]
             random_number = random.choice(numbers)
-            self.assertIn(random_number, numbers)
+            print(random_number in numbers)
             """)
 
     def test_random(self):

--- a/tests/structures/test_assignment.py
+++ b/tests/structures/test_assignment.py
@@ -50,9 +50,12 @@ class AssignmentTests(TranspileTestCase):
     def test_use_potentially_unassigned(self):
         self.assertCodeExecution("""
             x = 37
-            if y > 0:
-                print("Yes")
-            else:
-                print("No")
+            try:
+                if y > 0:
+                    print("Yes")
+                else:
+                    print("No")
+            except NameError as e:
+                print(e)
             print('Done.')
             """, run_in_function=False)

--- a/tests/structures/test_class.py
+++ b/tests/structures/test_class.py
@@ -74,15 +74,24 @@ class ClassTests(TranspileTestCase):
             obj3.__getattr__ = g
 
             print(obj1.foo)
-            print(obj1.fail)
+            try:
+                print(obj1.fail)
+            except AttributeError as e:
+                print(e)
             print(obj1.foo)
 
             print(obj2.x)
-            print(obj2.fail)
+            try:
+                print(obj2.fail)
+            except AttributeError as e:
+                print(e)
             print(obj2.x)
 
             print(obj3.x)
-            print(obj3.fail)
+            try:
+                print(obj3.fail)
+            except AttributeError as e:
+                print(e)
             print(obj3.x)
         """)
 
@@ -155,7 +164,10 @@ class ClassTests(TranspileTestCase):
 
             print(MyClass.foo)
             print(obj.a)
-            print(obj.fail)
+            try:
+                print(obj.fail)
+            except AttributeError as e:
+                print(e)
         """)
 
     def test_subclass(self):

--- a/tests/structures/test_datamodel.py
+++ b/tests/structures/test_datamodel.py
@@ -505,7 +505,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
                     return self
 
             p1 = Pair(5, 6)
-            p2 |= Pair(6, 5)
+            p1 |= Pair(6, 5)
 
             print(p1)
         """, run_in_function=False)

--- a/tests/structures/test_exception.py
+++ b/tests/structures/test_exception.py
@@ -7,7 +7,7 @@ class ExceptionTests(TranspileTestCase):
         # Caught exception
         self.assertCodeExecution("""
             raise KeyError("This is the name")
-            """)
+            """, allow_exceptions=True)
 
     def test_raise_catch(self):
         self.assertCodeExecution("""

--- a/tests/structures/test_generator.py
+++ b/tests/structures/test_generator.py
@@ -41,7 +41,10 @@ class GeneratorTests(TranspileTestCase):
                     x = (yield)
                     print('>>', x)
 
-            g().send(1)
+            try:
+                g().send(1)
+            except TypeError as e:
+                print(e)
         """)
 
     def test_simple_send(self):

--- a/tests/structures/test_scope.py
+++ b/tests/structures/test_scope.py
@@ -18,7 +18,10 @@ class ScopeTests(TranspileTestCase):
             x = 1
 
             def foo():
-                print("1: x =", x)
+                try:
+                    print("1: x =", x)
+                except UnboundLocalError as e:
+                    print(e)
                 x = 2
                 print("2: x =", x)
 
@@ -52,7 +55,10 @@ class ScopeTests(TranspileTestCase):
 
             class Foo:
                 def __init__(self, y):
-                    print("1: x =", x)
+                    try:
+                        print("1: x =", x)
+                    except UnboundLocalError as e:
+                        print(e)
                     print("1: y =", y)
                     x = 2
                     print("2: x =", x)

--- a/tests/structures/test_try_catch.py
+++ b/tests/structures/test_try_catch.py
@@ -67,7 +67,7 @@ class TryExceptTests(TranspileTestCase):
             except NameError:
                 print("Got an error")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_except_named(self):
         # No exception
@@ -98,7 +98,7 @@ class TryExceptTests(TranspileTestCase):
             except NameError as e:
                 print("Got a NameError")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except(self):
         # No exception
@@ -147,7 +147,7 @@ class TryExceptTests(TranspileTestCase):
             except AttributeError:
                 print("Got an AttributeError")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except_named(self):
         # No exception
@@ -196,7 +196,7 @@ class TryExceptTests(TranspileTestCase):
             except AttributeError as e:
                 print("Got an AttributeError")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_match_except_unnamed(self):
         # No exception
@@ -269,7 +269,7 @@ class TryExceptTests(TranspileTestCase):
             except AttributeError:
                 print("Got an AttributeError")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_match_except_named(self):
         # No exception
@@ -342,7 +342,7 @@ class TryExceptTests(TranspileTestCase):
             except AttributeError as e:
                 print("Got an AttributeError")
             print('Done 6.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except_mixed1(self):
         # No exception
@@ -379,7 +379,7 @@ class TryExceptTests(TranspileTestCase):
             except AttributeError as e:
                 print("Got an AttributeError")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except_mixed2(self):
         self.assertCodeExecution("""
@@ -413,7 +413,7 @@ class TryExceptTests(TranspileTestCase):
             except AttributeError:
                 print("Got an AttributeError")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except_mixed3(self):
         # No exception
@@ -479,7 +479,7 @@ class TryExceptFinallyTests(TranspileTestCase):
             finally:
                 print("Do final cleanup")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_except_finally(self):
         # Caught Exception
@@ -541,7 +541,7 @@ class TryExceptFinallyTests(TranspileTestCase):
             finally:
                 print("Do final cleanup")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_except_named_finally(self):
         # No exception
@@ -578,7 +578,7 @@ class TryExceptFinallyTests(TranspileTestCase):
             finally:
                 print("Do final cleanup")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except_finally(self):
         # No exception
@@ -635,7 +635,7 @@ class TryExceptFinallyTests(TranspileTestCase):
             finally:
                 print("Do final cleanup")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
 
 class TryExceptElseTests(TranspileTestCase):
@@ -699,7 +699,7 @@ class TryExceptElseTests(TranspileTestCase):
             else:
                 print("Do else handling")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except_else(self):
         # No exception
@@ -742,7 +742,7 @@ class TryExceptElseTests(TranspileTestCase):
             else:
                 print("Do else handling")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
 
 class TryExceptElseFinallyTests(TranspileTestCase):
@@ -816,7 +816,7 @@ class TryExceptElseFinallyTests(TranspileTestCase):
             finally:
                 print("Do final cleanup")
             print('Done.')
-            """)
+            """, allow_exceptions=True)
 
     def test_try_multiple_except_else_finally(self):
         # No exception
@@ -865,4 +865,4 @@ class TryExceptElseFinallyTests(TranspileTestCase):
             finally:
                 print("Do final cleanup")
             print('Done.')
-            """)
+            """, allow_exceptions=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import unittest
 
-from .utils import adjust, JSCleaner, PYCleaner, TranspileTestCase
+from .utils import adjust, JSCleaner, PYCleaner, TranspileTestCase, remove_whitespace, wrap_in_exception_guard, \
+    wrap_in_function
 
 
 class TimeoutTests(TranspileTestCase):
@@ -12,6 +13,62 @@ class TimeoutTests(TranspileTestCase):
 
 
 class AdjustTests(unittest.TestCase):
+    def test_remove_whitespace(self):
+        """Test input is stripped and split into lines."""
+        self.assertEqual(
+            remove_whitespace(
+                """
+                while True:
+                    print('----')
+                """, indent=False),
+            [
+                "while True:",
+                "    print('----')",
+                ""
+            ])
+
+    def test_remove_whitespace_and_indent(self):
+        """Test input is stripped and split into lines and indented."""
+        self.assertEqual(
+            remove_whitespace(
+                """
+                while True:
+                    print('----')
+                """, indent=True),
+            [
+                "    while True:",
+                "        print('----')",
+                ""
+            ])
+
+    def test_wrap_in_exception_guard(self):
+        self.assertEqual(
+            wrap_in_exception_guard(
+                """
+                print("banana")
+                """
+            ),
+            """\
+try:
+    print("banana")
+
+except Exception as e:
+    print("Exception escaped test code in TEST_RUNNER_TARGET")
+    print(repr(e))""")
+
+    def test_wrap_in_function(self):
+        self.assertEqual(
+            wrap_in_function(
+                """
+                print("banana")
+                """
+            ),
+            """\
+def test_function():
+    print("banana")
+
+test_function()""")
+
     def assertEqualOutput(self, actual, expected):
         self.assertEqual(adjust(actual), adjust(expected))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -152,32 +152,35 @@ def capture_output(redirect_stderr=True):
         sys.stdout, sys.stderr = oldout, olderr
 
 
+def remove_whitespace(text, indent=False):
+    lines = text.split('\n')
+
+    if lines[0].strip() == '':
+        lines = lines[1:]
+    first_line = lines[0].lstrip()
+    n_spaces = len(lines[0]) - len(first_line)
+
+    return [('    ' if indent and line[n_spaces:] else '') + line[n_spaces:] for line in lines]
+
+
+def wrap_in_function(code_to_wrap):
+    return '\n'.join(
+        ["def test_function():"]
+        + remove_whitespace(code_to_wrap, indent=True)
+        + ["test_function()"])
+
+
+def wrap_in_exception_guard(code_to_wrap):
+    return '\n'.join(
+        ["try:"]
+        + remove_whitespace(code_to_wrap, indent=True)
+        + ["except Exception as e:",
+           "    print(\"Exception escaped test code in TEST_RUNNER_TARGET\")",
+           "    print(repr(e))"])
+
+
 def adjust(code_snippet, run_in_function=False, wrap_in_try_catch=False):
     """Adjust a code sample to remove leading whitespace and add wrapping code."""
-
-    def remove_whitespace(text, indent=False):
-        lines = text.split('\n')
-
-        if lines[0].strip() == '':
-            lines = lines[1:]
-        first_line = lines[0].lstrip()
-        n_spaces = len(lines[0]) - len(first_line)
-
-        return [('    ' if indent else '') + line[n_spaces:] for line in lines]
-
-    def wrap_in_function(code_to_wrap):
-        return '\n'.join(
-            ["def test_function():"]
-            + remove_whitespace(code_to_wrap, indent=True)
-            + ["test_function()"])
-
-    def wrap_in_exception_guard(code_to_wrap):
-        return '\n'.join(
-            ["try:"]
-            + remove_whitespace(code_to_wrap, indent=True)
-            + ["except Exception as e:",
-               "    print(\"Exception escaped test code in TEST_RUNNER_TARGET\")",
-               "    print(repr(e))"])
 
     if run_in_function:
         code_snippet = wrap_in_function(code_snippet)


### PR DESCRIPTION
This add a default test to assertCodeExecution that no exception was thrown and not caught within the test code, and fixes the many places where this was happening.

There is an allow_exceptions parameter to use for cases where the test is specifically testing that exceptions can be thrown and not caught.

This is a solution to #792.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
