### PR TITLE
Add check to assertCodeExecution that something was output and fix tests

### DIFF
--- a/tests/modules/test_json/test_decoding.py
+++ b/tests/modules/test_json/test_decoding.py
@@ -1,3 +1,5 @@
+import unittest
+
 from ...utils import TranspileTestCase, ModuleFunctionTestCase, adjust
 from .JSON_data import pass_data, fail_data
 
@@ -22,13 +24,14 @@ class LoadsTests(ModuleFunctionTestCase, TranspileTestCase):
                 run_in_function=False,
             )
 
+    @unittest.expectedFailure
     def test_fail(self):
         for data in fail_data:
             self.assertCodeExecution(
                 adjust("""
                     import json
                     try:
-                       json.loads(r'''{}''')
+                       print(json.loads(r'''{}'''))
                     except Exception as e:
                        print(type(e))
                 """).format(data),
@@ -122,9 +125,9 @@ class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
     not_implemented_versions = {
     }
 
-    not_implemented = [
-        'test_fail',
-    ]
+    not_implemented = {
+        'test_fail'
+    }
 
     fp_def = """class fp:
     def __init__(self, doc):
@@ -139,10 +142,12 @@ class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
                     import json
                     {}
                     json.load(fp(r'''{}'''))
+                    print('No exception was thrown during decoding.')
                 """).format(self.fp_def, data),
                 run_in_function=False,
             )
 
+    @unittest.expectedFailure
     def test_fail(self):
         for data in fail_data:
             self.assertCodeExecution(
@@ -150,7 +155,7 @@ class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
                     import json
                     {}
                     try:
-                       json.load(fp(r'''{}'''))
+                       print(json.load(fp(r'''{}''')))
                     except Exception as e:
                        print(type(e))
                 """).format(self.fp_def, data),
@@ -289,6 +294,7 @@ class JSONDecoderTests(ModuleFunctionTestCase, TranspileTestCase):
                 adjust("""
                     import json
                     json.JSONDecoder().decode(r'''{}''')
+                    print("No exception was thrown.")
                 """).format(data),
                 run_in_function=False,
             )
@@ -299,7 +305,7 @@ class JSONDecoderTests(ModuleFunctionTestCase, TranspileTestCase):
                 adjust("""
                     import json
                     try:
-                       json.JSONDecoder().decode(r'''{}''')
+                       print(json.JSONDecoder().decode(r'''{}'''))
                     except Exception as e:
                        print(type(e))
                 """).format(data),

--- a/tests/modules/test_json/test_decoding.py
+++ b/tests/modules/test_json/test_decoding.py
@@ -125,9 +125,9 @@ class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
     not_implemented_versions = {
     }
 
-    not_implemented = {
-        'test_fail'
-    }
+    not_implemented = [
+        'test_fail',
+    ]
 
     fp_def = """class fp:
     def __init__(self, doc):

--- a/tests/modules/test_webbrowser.py
+++ b/tests/modules/test_webbrowser.py
@@ -1,8 +1,9 @@
 from ..utils import TranspileTestCase
 
+
 class WebbrowserTests(TranspileTestCase):
     def test_import(self):
         self.assertCodeExecution("""
             import webbrowser
+            print('Done.')
             """)
-

--- a/tests/utils/transpile_test_case.py
+++ b/tests/utils/transpile_test_case.py
@@ -179,6 +179,7 @@ class TranspileTestCase(TestCase):
                 context = 'Global context'
 
             self.assertEqual(js_out, py_out, context)
+            self.assertNotEqual(js_out, '', msg="Test had no output. Nothing was tested. %s" % context)
 
         # ==================================================
         # Pass 2 - run the code in a function's context
@@ -222,6 +223,7 @@ class TranspileTestCase(TestCase):
                 context = 'Function context'
 
             self.assertEqual(js_out, py_out, context)
+            self.assertNotEqual(js_out, '', msg="Test had no output. Nothing was tested. %s" % context)
 
     def assertJavaScriptExecution(self, code, out, extra_code=None, js=None, run_in_global=True, run_in_function=True,
                                   args=None, substitutions=None, same=True, js_cleaner=JSCleaner()):


### PR DESCRIPTION
This updates the comparison logic after testing in JS and Python to include a check for both being empty.

There were a few tests that failed this check, but, happily, no test failure was hidden by this.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
