### PR TITLE
Remove Support for Python 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,14 @@ README.md
 node_modules/
 package/
 npm-debug.log
+test-py35-node10.xml
+test-py35-node6.xml
 
 # PyCharm settings
 .idea
+
+# VSCode settings
+.vscode
 
 # Py.test
 .cache
@@ -41,4 +46,5 @@ npm-debug.log
 
 # local environment configuration
 .env
+.venv
 /.cache-loader/

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Batavia
 Batavia is an implementation of the Python virtual machine, written in
 JavaScript. With Batavia, you can run Python bytecode in your browser.
 
-It honors Python 3.4.4+ syntax and conventions, and allows you to
+It honors Python 3.5+ syntax and conventions, and allows you to
 reference objects and classes defined natively in JavaScript.
 
 Quick Start

--- a/README.rst
+++ b/README.rst
@@ -35,11 +35,11 @@ Quick Start
 Prerequisites
 ~~~~~~~~~~~~~~
 
-Batavia requires a Python 3.4 or Python 3.5 installation, and a virtualenv to
-run it all in.  Python 3.6 is not yet supported.
+Batavia requires a Python 3.5 or Python 3.6 installation, and a virtualenv to
+run it all in.  Python 3.7 runs but is less usable at this point.
 
 You also need to have a recent install of `Node.js <https://nodejs.org>`_
-(from the “stable” 6.X series), and a current version of npm. If
+(from the 10.x LTR series), and a current version of npm. If
 your version of npm is outdated, you can update it using the command::
 
 $ npm install npm@latest -g
@@ -66,7 +66,7 @@ Downloading and Installing
 Linux/Unix/Mac
 --------------
 Check your python3 version first.  If it's pointing to version 3.6, replace ``$(which python3)`` in the virtualenv command
-below with the path to your Python 3.4 or 3.5 installation. ::
+below with the path to your Python 3.5 or 3.6 installation. ::
 
 $ python3 --version
 $ python3 -m venv venv
@@ -97,7 +97,9 @@ Type in the following commands in your terminal ::
 
 3. Install `Node.js <https://nodejs.org>`_.
 
-You must have a recent version of Node; we do our testing using v6.9.1. Once you've installed Node, you can use it to install the JavaScript dependencies and compile the Batavia library::
+You must have a recent version of Node; we do our testing using v10.x. Once
+you've installed Node, you can use it to install the JavaScript dependencies
+and compile the Batavia library::
 
 $ npm install
 

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1522,11 +1522,6 @@ VirtualMachine.prototype.byte_WITH_CLEANUP = function() {
 }
 
 VirtualMachine.prototype.byte_WITH_CLEANUP_FINISH = function() {
-    if (version.earlier('3.5a0')) {
-        throw new builtins.BataviaError.$pyclass(
-            'Unknown opcode WITH_CLEANUP_FINISH in Python 3.4'
-        )
-    }
     // Assuming Python 3.5
     var ret = this.pop()
     var exc = this.pop()

--- a/batavia/builtins/bytearray.js
+++ b/batavia/builtins/bytearray.js
@@ -14,11 +14,7 @@ function asBytes(value) {
 }
 
 function requiresInteger(value) {
-    if (version.later('3.6')) {
-        throw new exceptions.TypeError.$pyclass("'" + type_name(value) + "' object cannot be interpreted as an integer")
-    } else {
-        throw new exceptions.TypeError.$pyclass('an integer is required')
-    }
+    throw new exceptions.TypeError.$pyclass('an integer is required')
 }
 
 bytearray.__call__ = function(args, kwargs) {

--- a/batavia/builtins/chr.js
+++ b/batavia/builtins/chr.js
@@ -11,15 +11,9 @@ function chr(args, kwargs) {
         throw new exceptions.TypeError.$pyclass('chr() takes no keyword arguments')
     }
     if (!args || args.length !== 1) {
-        if (version.later('3.4')) {
-            throw new exceptions.TypeError.$pyclass(
-                'chr() takes exactly one argument (' + args.length + ' given)'
-            )
-        } else {
-            throw new exceptions.TypeError.$pyclass(
-                'chr() takes exactly 1 argument (' + args.length + ' given)'
-            )
-        }
+        throw new exceptions.TypeError.$pyclass(
+            'chr() takes exactly one argument (' + args.length + ' given)'
+        )
     }
     if (types.isinstance(args[0], types.Complex)) {
         throw new exceptions.TypeError.$pyclass('can\'t convert complex to int')

--- a/batavia/core/constants.js
+++ b/batavia/core/constants.js
@@ -10,7 +10,6 @@ var constants = {
     'BATAVIA_MAGIC': null,
 
     // set in PYCFile while parsing python bytecode
-    'BATAVIA_MAGIC_35a0': String.fromCharCode(248, 12, 13, 10),
     'BATAVIA_MAGIC_35': String.fromCharCode(22, 13, 13, 10),
     'BATAVIA_MAGIC_353': String.fromCharCode(23, 13, 13, 10),
     'BATAVIA_MAGIC_36': String.fromCharCode(51, 13, 13, 10)

--- a/batavia/core/constants.js
+++ b/batavia/core/constants.js
@@ -10,7 +10,6 @@ var constants = {
     'BATAVIA_MAGIC': null,
 
     // set in PYCFile while parsing python bytecode
-    'BATAVIA_MAGIC_34': String.fromCharCode(238, 12, 13, 10),
     'BATAVIA_MAGIC_35a0': String.fromCharCode(248, 12, 13, 10),
     'BATAVIA_MAGIC_35': String.fromCharCode(22, 13, 13, 10),
     'BATAVIA_MAGIC_353': String.fromCharCode(23, 13, 13, 10),

--- a/batavia/core/version.js
+++ b/batavia/core/version.js
@@ -4,8 +4,6 @@ var exceptions = require('./exceptions')
 var version = {}
 
 var magic_map = {}
-magic_map[String.fromCharCode(238, 12, 13, 10)] = [[3, 4], [0xF]]
-magic_map[String.fromCharCode(248, 12, 13, 10)] = [[3, 5], [0xA, 0]]
 magic_map[String.fromCharCode(22, 13, 13, 10)] = [[3, 5], [0xF]]
 magic_map[String.fromCharCode(23, 13, 13, 10)] = [[3, 5, 3], [0xF]]
 magic_map[String.fromCharCode(51, 13, 13, 10)] = [[3, 6, 2], [0xF]]

--- a/batavia/modules/math.js
+++ b/batavia/modules/math.js
@@ -89,7 +89,7 @@ math.ceil = function(x) {
     _checkFloat(x)
     return new types.Int(Math.ceil(x.__float__().val))
 }
-math.ceil.__doc__ = 'ceil(x)\n\nReturn the ceiling of x as an int.\nThis is the smallest integral value >= x.'
+math.ceil.__doc__ = 'ceil(x)\n\nReturn the ceiling of x as an Integral.\nThis is the smallest integer >= x.'
 
 math.copysign = function(x, y) {
     _checkFloat(y)
@@ -306,7 +306,7 @@ math.floor = function(x) {
     _checkFloat(x)
     return new types.Int(Math.floor(x.__float__().val))
 }
-math.floor.__doc__ = 'floor(x)\n\nReturn the floor of x as an int.\nThis is the largest integral value <= x.'
+math.floor.__doc__ = 'floor(x)\n\nReturn the floor of x as an Integral.\nThis is the largest integer <= x.'
 
 math.fmod = function(x, y) {
     _checkFloat(y)

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -530,9 +530,6 @@ List.prototype.__getitem__ = function(index) {
         }
     } else {
         var msg = 'list indices must be integers or slices, not '
-        if (!version.later('3.4')) {
-            msg = 'list indices must be integers, not '
-        }
         throw new exceptions.TypeError.$pyclass(msg + type_name(index))
     }
 }

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -475,7 +475,7 @@ Str.prototype.__rmul__ = function(other) {
 
 /**************************************************
  * Methods
- * https://docs.python.org/3.4/library/stdtypes.html#string-methods
+ * https://docs.python.org/3.6/library/stdtypes.html#string-methods
  **************************************************/
 
 Str.prototype.__len__ = function() {

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -414,9 +414,6 @@ Tuple.prototype.__getitem__ = function(index) {
         return new Tuple(steppedArray)
     } else {
         var msg = 'tuple indices must be integers or slices, not '
-        if (!version.later('3.4')) {
-            msg = 'tuple indices must be integers, not '
-        }
         throw new exceptions.TypeError.$pyclass(msg + type_name(index))
     }
 }

--- a/beekeeper.yml
+++ b/beekeeper.yml
@@ -18,10 +18,6 @@ pull_request:
                 name: Python 3.6 tests
                 task: batavia-py36
                 critical: False
-            - py3.7:
-                name: Python 3.7 tests
-                task: batavia-py37
-                critical: False
         profile: hi-cpu
 push:
     - smoke-test:

--- a/beekeeper.yml
+++ b/beekeeper.yml
@@ -9,22 +9,22 @@ pull_request:
                 name: Python lint checks
                 task: beefore
     - smoke-test:
-        task: batavia-py34
-        name: Smoke build (Python 3.4)
+        task: batavia-py35
+        name: Smoke build (Python 3.5)
         profile: hi-cpu
     - full-test:
         subtasks:
-            - py3.5:
-                name: Python 3.5 tests
-                task: batavia-py35
-                critical: False
             - py3.6:
                 name: Python 3.6 tests
                 task: batavia-py36
                 critical: False
+            - py3.7:
+                name: Python 3.7 tests
+                task: batavia-py37
+                critical: False
         profile: hi-cpu
 push:
     - smoke-test:
-        task: batavia-py34
-        name: Smoke build (Python 3.4)
+        task: batavia-py35
+        name: Smoke build (Python 3.5)
         profile: hi-cpu

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -18,7 +18,7 @@ instead of using the official BeeWare repository, you'll be using your own
 Github fork.
 
 As with the getting started guide, these instructions will assume that you
-have Python 3 (currently supported versions are 3.4 to 3.6).
+have Python 3 (currently supported versions are 3.5 and 3.6).
 
 Batavia codebase
 ^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ Install Node.JS
 ^^^^^^^^^^^^^^^
 
 Lastly, you'll need to install `Node.js`_. You need to have a recent version
-of Node; we test using v6.9.1. Once you've installed node, you can use it to
+of Node; we test using v10.x. Once you've installed node, you can use it to
 install Batavia's JavaScript dependencies, and compile the Batavia library:
 
 .. code-block:: bash
@@ -70,17 +70,17 @@ Raspbian/Raspberry Pi
 This has been successfully tested on Raspbian GNU/Linux 7 (wheezy), based on
 instructions from `Procrastinative Ninja`_ and `aeberhardo`_.
 
-Raspbian for Raspberry Pi 1 does not come with Python 3.4.  (Ubuntu 16.04 for Raspberry
+Raspbian for Raspberry Pi 1 does not come with Python 3.6.  (Ubuntu 16.04 for Raspberry
 Pi is now available, and has new enough packages as described above.) To install Python
-3.4, download the source code and then build it:
+3.6, download the source code and then build it:
 
 .. code-block:: bash
 
 	$ cd /tmp
-	$ wget https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tgz
-	$ tar xvzf Python-3.4.8.tgz
-	$ cd Python-3.4.8/
-	$ ./configure --prefix=/opt/python3.4
+	$ wget https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz
+	$ tar xvzf Python-3.6.8.tgz
+	$ cd Python-3.6.8/
+	$ ./configure --prefix=/opt/python3.6
 	$ make
 	$ sudo make install
 

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -41,9 +41,9 @@ Then create a virtual environment and install Batavia into it:
    $ cd batavia
    $ pip install -e .
 
- * For Windows (assuming Python 3.4)::
+ * For Windows (assuming Python 3.6)::
 
-   > py -3.4 -m venv venv
+   > py -3.6 -m venv venv
    > venv\Scripts\activate
    > cd batavia
    > pip install -e .

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -4,7 +4,7 @@ Tutorial: Preparing your Environment for Batavia Development
 Getting a working local copy of Batavia requires a few steps: getting a copy of
 the Batavia code, and the ouroboros dependency within a virtual environment.
 
-You'll need to have Python 3.5 available for Batavia to work. Instructions on
+You'll need to have Python 3.5 or 3.6 available for Batavia to work. Instructions on
 how to set this up are `on our Environment setup guide
 <http://beeware.org/contributing/how/first-time/setup/>`_.
 
@@ -60,11 +60,11 @@ how to set this up are `on our Environment setup guide
 
    $ node --version
 
-   If you have an older version of Node.js, or a version from the 7.X or 8.X series,
-   you will need to download and install a version from the "stable" 6.X series.
+   If you have an older version of Node.js, or a version from the 11.x,
+   you will need to download and install a version from the "stable" 10.x series.
 
    Once you've installed node, you need to make sure you have a current version
-   of npm. Batavia requires npm v4.0 or greater; you can determine what version
+   of npm. Batavia requires npm v6.0 or greater; you can determine what version
    of npm you have by running::
 
    $ npm --version
@@ -101,7 +101,7 @@ command line <tutorial-2>`.
 Troubleshooting Tips
 --------------------
 
-After running "npm run build", if  you recieve the error::
+After running "npm run build", if  you receive the error::
 
    "Module not found: Error: Cannot resolve 'file' or 'directory' ./stdlib"
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='russell@keith-magee.com',
     url=data['homepage'],
     packages=find_packages(exclude=['docs', 'tests']),
-    python_requires='>=3.4, <3.7',
+    python_requires='>=3.5',
     license='New BSD',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
@@ -27,7 +27,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='russell@keith-magee.com',
     url=data['homepage'],
     packages=find_packages(exclude=['docs', 'tests']),
-    python_requires='>=3.5',
+    python_requires='>=3.5, <3.7',
     license='New BSD',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/tests/builtins/test_dir.py
+++ b/tests/builtins/test_dir.py
@@ -12,8 +12,6 @@ class BuiltinDirFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_None': ['3.6'],
         'test_NotImplemented': ['3.6'],
         'test_bool': ['3.6'],
-        'test_bytearray': ['3.5', '3.6'],
-        'test_bytes': ['3.5', '3.6'],
         'test_complex': ['3.6'],
         'test_dict': ['3.6'],
         'test_float': ['3.6'],
@@ -21,7 +19,6 @@ class BuiltinDirFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_int': ['3.6'],
         'test_list': ['3.6'],
         'test_noargs': ['3.6'],
-        'test_range': ['3.5', '3.6'],
         'test_set': ['3.6'],
         'test_slice': ['3.6'],
         'test_str': ['3.6'],
@@ -29,5 +26,8 @@ class BuiltinDirFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     }
 
     not_implemented = [
+        'test_bytearray',
+        'test_bytes',
         'test_class',
+        'test_range',
     ]

--- a/tests/builtins/test_sorted.py
+++ b/tests/builtins/test_sorted.py
@@ -8,10 +8,6 @@ class SortedTests(TranspileTestCase):
 class BuiltinSortedFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "sorted"
 
-    not_implemented_versions = {
-        'test_noargs': '3.6',
-    }
-
     not_implemented = [
         'test_bool',
         'test_bytearray',

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -34,6 +34,24 @@ class MagicMethodFunctionTests(MagicMethodFunctionTestCase, TranspileTestCase):
         "test__imul__str",
         "test__imul__tuple",
 
+        "test__mod__bool",
+        "test__mod__bytearray",
+        "test__mod__bytes",
+        "test__mod__class",
+        "test__mod__complex",
+        "test__mod__dict",
+        "test__mod__float",
+        "test__mod__frozenset",
+        "test__mod__int",
+        "test__mod__list",
+        "test__mod__None",
+        "test__mod__NotImplemented",
+        "test__mod__range",
+        "test__mod__set",
+        "test__mod__slice",
+        "test__mod__str".
+        "test__mod__tuple",
+
         "test__mul__bool",
         "test__mul__bytearray",
         "test__mul__bytes",
@@ -51,6 +69,8 @@ class MagicMethodFunctionTests(MagicMethodFunctionTestCase, TranspileTestCase):
         "test__mul__slice",
         "test__mul__str",
         "test__mul__tuple",
+
+        "test__rmod__bytearray",
 
         "test__rmul__bool",
         "test__rmul__bytearray",
@@ -72,27 +92,6 @@ class MagicMethodFunctionTests(MagicMethodFunctionTestCase, TranspileTestCase):
     ]
 
     not_implemented_versions = {
-        "test__mod__bool": ['3.5', '3.6'],
-        "test__mod__bytearray": ['3.5', '3.6'],
-        "test__mod__bytes": ['3.5', '3.6'],
-        "test__mod__class": ['3.5', '3.6'],
-        "test__mod__complex": ['3.5', '3.6'],
-        "test__mod__dict": ['3.5', '3.6'],
-        "test__mod__float": ['3.5', '3.6'],
-        "test__mod__frozenset": ['3.5', '3.6'],
-        "test__mod__int": ['3.5', '3.6'],
-        "test__mod__list": ['3.5', '3.6'],
-        "test__mod__None": ['3.5', '3.6'],
-        "test__mod__NotImplemented": ['3.5', '3.6'],
-        "test__mod__range": ['3.5', '3.6'],
-        "test__mod__set": ['3.5', '3.6'],
-        "test__mod__slice": ['3.5', '3.6'],
-        "test__mod__str": ['3.5', '3.6'],
-        "test__mod__tuple": ['3.5', '3.6'],
-
-        "test__rmod__bytearray": ['3.5', '3.6'],
-
-        "test__rmod__missing": ['3.4'],
     }
 
 
@@ -179,6 +178,24 @@ class BinaryBytearrayOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_lt_str',
         'test_lt_tuple',
 
+        'test_modulo_bool',
+        'test_modulo_bytearray',
+        'test_modulo_bytes',
+        'test_modulo_class',
+        'test_modulo_complex',
+        'test_modulo_dict',
+        'test_modulo_float',
+        'test_modulo_frozenset',
+        'test_modulo_int',
+        'test_modulo_list',
+        'test_modulo_None',
+        'test_modulo_NotImplemented',
+        'test_modulo_range',
+        'test_modulo_set',
+        'test_modulo_slice',
+        'test_modulo_str',
+        'test_modulo_tuple',
+
         'test_multiply_bool',
         'test_multiply_int',
 
@@ -204,23 +221,6 @@ class BinaryBytearrayOperationTests(BinaryOperationTestCase, TranspileTestCase):
     ]
 
     not_implemented_versions = {
-        'test_modulo_bool': ['3.5', '3.6'],
-        'test_modulo_bytearray': ['3.5', '3.6'],
-        'test_modulo_bytes': ['3.5', '3.6'],
-        'test_modulo_class': ['3.5', '3.6'],
-        'test_modulo_complex': ['3.5', '3.6'],
-        'test_modulo_dict': ['3.5', '3.6'],
-        'test_modulo_float': ['3.5', '3.6'],
-        'test_modulo_frozenset': ['3.5', '3.6'],
-        'test_modulo_int': ['3.5', '3.6'],
-        'test_modulo_list': ['3.5', '3.6'],
-        'test_modulo_None': ['3.5', '3.6'],
-        'test_modulo_NotImplemented': ['3.5', '3.6'],
-        'test_modulo_range': ['3.5', '3.6'],
-        'test_modulo_set': ['3.5', '3.6'],
-        'test_modulo_slice': ['3.5', '3.6'],
-        'test_modulo_str': ['3.5', '3.6'],
-        'test_modulo_tuple': ['3.5', '3.6'],
     }
 
 
@@ -228,26 +228,27 @@ class InplaceBytearrayOperationTests(InplaceOperationTestCase, TranspileTestCase
     data_type = 'bytearray'
 
     not_implemented = [
+        'test_modulo_bool',
+        'test_modulo_bytearray',
+        'test_modulo_bytes',
+        'test_modulo_None',
+        'test_modulo_NotImplemented',
+        'test_modulo_class',
+        'test_modulo_complex',
+        'test_modulo_dict',
+        'test_modulo_float',
+        'test_modulo_frozenset',
+        'test_modulo_int',
+        'test_modulo_list',
+        'test_modulo_range',
+        'test_modulo_set',
+        'test_modulo_slice',
+        'test_modulo_str',
+        'test_modulo_tuple',
+
         'test_multiply_bool',
         'test_multiply_int',
     ]
 
     not_implemented_versions = {
-        'test_modulo_bool': ['3.5', '3.6'],
-        'test_modulo_bytearray': ['3.5', '3.6'],
-        'test_modulo_bytes': ['3.5', '3.6'],
-        'test_modulo_None': ['3.5', '3.6'],
-        'test_modulo_NotImplemented': ['3.5', '3.6'],
-        'test_modulo_class': ['3.5', '3.6'],
-        'test_modulo_complex': ['3.5', '3.6'],
-        'test_modulo_dict': ['3.5', '3.6'],
-        'test_modulo_float': ['3.5', '3.6'],
-        'test_modulo_frozenset': ['3.5', '3.6'],
-        'test_modulo_int': ['3.5', '3.6'],
-        'test_modulo_list': ['3.5', '3.6'],
-        'test_modulo_range': ['3.5', '3.6'],
-        'test_modulo_set': ['3.5', '3.6'],
-        'test_modulo_slice': ['3.5', '3.6'],
-        'test_modulo_str': ['3.5', '3.6'],
-        'test_modulo_tuple': ['3.5', '3.6'],
     }

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -49,7 +49,7 @@ class MagicMethodFunctionTests(MagicMethodFunctionTestCase, TranspileTestCase):
         "test__mod__range",
         "test__mod__set",
         "test__mod__slice",
-        "test__mod__str".
+        "test__mod__str",
         "test__mod__tuple",
 
         "test__mul__bool",

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -103,6 +103,23 @@ class MagicMethodFunctionTests(MagicMethodFunctionTestCase, TranspileTestCase):
     MagicMethodFunctionTestCase._add_tests(vars(), bytes)
 
     not_implemented = [
+        "test__mod__bool",
+        "test__mod__bytearray",
+        "test__mod__bytes",
+        "test__mod__class",
+        "test__mod__complex",
+        "test__mod__dict",
+        "test__mod__float",
+        "test__mod__frozenset",
+        "test__mod__int",
+        "test__mod__list",
+        "test__mod__None",
+        "test__mod__NotImplemented",
+        "test__mod__range",
+        "test__mod__set",
+        "test__mod__slice",
+        "test__mod__str",
+        "test__mod__tuple",
         "test__mul__bytearray",
         "test__mul__bytes",
         "test__mul__class",
@@ -123,27 +140,6 @@ class MagicMethodFunctionTests(MagicMethodFunctionTestCase, TranspileTestCase):
     ]
 
     not_implemented_versions = {
-        "test__mod__bool": ['3.5', '3.6'],
-        "test__mod__bytearray": ['3.5', '3.6'],
-        "test__mod__bytes": ['3.5', '3.6'],
-        "test__mod__class": ['3.5', '3.6'],
-        "test__mod__complex": ['3.5', '3.6'],
-        "test__mod__dict": ['3.5', '3.6'],
-        "test__mod__float": ['3.5', '3.6'],
-        "test__mod__frozenset": ['3.5', '3.6'],
-        "test__mod__int": ['3.5', '3.6'],
-        "test__mod__list": ['3.5', '3.6'],
-        "test__mod__None": ['3.5', '3.6'],
-        "test__mod__NotImplemented": ['3.5', '3.6'],
-        "test__mod__range": ['3.5', '3.6'],
-        "test__mod__set": ['3.5', '3.6'],
-        "test__mod__slice": ['3.5', '3.6'],
-        "test__mod__str": ['3.5', '3.6'],
-        "test__mod__tuple": ['3.5', '3.6'],
-
-        "test__rmod__bytes": ['3.5', '3.6'],
-
-        "test__rmod__missing": ['3.4'],
     }
 
 
@@ -155,40 +151,27 @@ class BinaryBytesOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'bytes'
 
     not_implemented_versions = {
-        'test_subscr_bytearray': ['3.4'],
-        'test_subscr_bytes': ['3.4'],
-        'test_subscr_class': ['3.4'],
-        'test_subscr_complex': ['3.4'],
-        'test_subscr_dict': ['3.4'],
-        'test_subscr_float': ['3.4'],
-        'test_subscr_frozenset': ['3.4'],
-        'test_subscr_list': ['3.4'],
-        'test_subscr_None': ['3.4'],
-        'test_subscr_NotImplemented': ['3.4'],
-        'test_subscr_range': ['3.4'],
-        'test_subscr_set': ['3.4'],
-        'test_subscr_str': ['3.4'],
-        'test_subscr_tuple': ['3.4'],
-        'test_modulo_None': ['3.5', '3.6'],
-        'test_modulo_NotImplemented': ['3.5', '3.6'],
-        'test_modulo_bool': ['3.5', '3.6'],
-        'test_modulo_bytearray': ['3.5', '3.6'],
-        'test_modulo_bytes': ['3.5', '3.6'],
-        'test_modulo_class': ['3.5', '3.6'],
-        'test_modulo_complex': ['3.5', '3.6'],
-        'test_modulo_dict': ['3.5', '3.6'],
-        'test_modulo_float': ['3.5', '3.6'],
-        'test_modulo_frozenset': ['3.5', '3.6'],
-        'test_modulo_int': ['3.5', '3.6'],
-        'test_modulo_list': ['3.5', '3.6'],
-        'test_modulo_range': ['3.5', '3.6'],
-        'test_modulo_set': ['3.5', '3.6'],
-        'test_modulo_slice': ['3.5', '3.6'],
-        'test_modulo_str': ['3.5', '3.6'],
-        'test_modulo_tuple': ['3.5', '3.6'],
     }
 
     not_implemented = [
+        'test_modulo_None',
+        'test_modulo_NotImplemented',
+        'test_modulo_bool',
+        'test_modulo_bytearray',
+        'test_modulo_bytes',
+        'test_modulo_class',
+        'test_modulo_complex',
+        'test_modulo_dict',
+        'test_modulo_float',
+        'test_modulo_frozenset',
+        'test_modulo_int',
+        'test_modulo_list',
+        'test_modulo_range',
+        'test_modulo_set',
+        'test_modulo_slice',
+        'test_modulo_str',
+        'test_modulo_tuple',
+
         'test_eq_bytearray',
 
         'test_ge_bytearray',
@@ -211,21 +194,24 @@ class InplaceBytesOperationTests(InplaceOperationTestCase, TranspileTestCase):
     data_type = 'bytes'
 
     not_implemented_versions = {
-        'test_modulo_None': ['3.5', '3.6'],
-        'test_modulo_NotImplemented': ['3.5', '3.6'],
-        'test_modulo_bool': ['3.5', '3.6'],
-        'test_modulo_bytearray': ['3.5', '3.6'],
-        'test_modulo_bytes': ['3.5', '3.6'],
-        'test_modulo_class': ['3.5', '3.6'],
-        'test_modulo_complex': ['3.5', '3.6'],
-        'test_modulo_dict': ['3.5', '3.6'],
-        'test_modulo_float': ['3.5', '3.6'],
-        'test_modulo_frozenset': ['3.5', '3.6'],
-        'test_modulo_int': ['3.5', '3.6'],
-        'test_modulo_list': ['3.5', '3.6'],
-        'test_modulo_range': ['3.5', '3.6'],
-        'test_modulo_set': ['3.5', '3.6'],
-        'test_modulo_slice': ['3.5', '3.6'],
-        'test_modulo_str': ['3.5', '3.6'],
-        'test_modulo_tuple': ['3.5', '3.6'],
     }
+
+    not_implemented = [
+        'test_modulo_None',
+        'test_modulo_NotImplemented',
+        'test_modulo_bool',
+        'test_modulo_bytearray',
+        'test_modulo_bytes',
+        'test_modulo_class',
+        'test_modulo_complex',
+        'test_modulo_dict',
+        'test_modulo_float',
+        'test_modulo_frozenset',
+        'test_modulo_int',
+        'test_modulo_list',
+        'test_modulo_range',
+        'test_modulo_set',
+        'test_modulo_slice',
+        'test_modulo_str',
+        'test_modulo_tuple',
+    ]

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -155,21 +155,6 @@ class DictTests(TranspileTestCase):
             print(foo)
             """)
 
-    def test_print_dict_bytecode_34(self):
-        # equivalent to
-        #   foo = {'a': 1}
-        #   print(foo)
-        # we are using explicit bytecode here so that we can test
-        # differences in Python bytecode between diff Py versions
-        # within a single test suite
-        bytecode = (
-            b'7gwNCsmyUFcaAAAA4wAAAAAAAAAAAAAAAAMAAABAAAAAcxsAAABpAQBkAABkAQA2WgAAZQEAZQAA\n'
-            b'gwEAAWQCAFMpA+kBAAAA2gFhTikC2gNmb2/aBXByaW50qQByBQAAAHIFAAAA+gd0ZXN0LnB52gg8\n'
-            b'bW9kdWxlPgEAAABzAgAAAA0B\n'
-        )
-        expected = "{'a': 1}\n"
-        self.assertJavaScriptExecution(bytecode, expected, js={})
-
     def test_print_dict_bytecode_35(self):
         # equivalent to
         #   foo = {'a': 1}

--- a/tests/modules/test_json/test_decoding.py
+++ b/tests/modules/test_json/test_decoding.py
@@ -6,8 +6,11 @@ from .JSON_data import pass_data, fail_data
 class LoadsTests(ModuleFunctionTestCase, TranspileTestCase):
 
     not_implemented_versions = {
-        'test_fail': ['3.5', '3.6']
     }
+
+    not_implemented = [
+        'test_fail',
+    ]
 
     def test_pass(self):
         for data in pass_data:
@@ -117,8 +120,11 @@ class LoadsTests(ModuleFunctionTestCase, TranspileTestCase):
 class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
 
     not_implemented_versions = {
-        'test_fail': ['3.5', '3.6']
     }
+
+    not_implemented = [
+        'test_fail',
+    ]
 
     fp_def = """class fp:
     def __init__(self, doc):
@@ -271,8 +277,11 @@ class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
 class JSONDecoderTests(ModuleFunctionTestCase, TranspileTestCase):
 
     not_implemented_versions = {
-        'test_fail': ['3.5', '3.6']
     }
+
+    not_implemented = [
+        'test_fail',
+    ]
 
     def test_pass(self):
         for data in pass_data:

--- a/tests/modules/test_math.py
+++ b/tests/modules/test_math.py
@@ -7,8 +7,11 @@ from ..utils import ModuleFunctionTestCase, TranspileTestCase
 class MathTests(ModuleFunctionTestCase, TranspileTestCase):
 
     not_implemented_versions = {
-        'test_docstrings': ['3.5', '3.6'],
     }
+
+    not_implemented = [
+        'test_docstrings',
+    ]
 
     substitutions = {
         # A

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34, py35, py36
+envlist = py35, py36
 
 [testenv]
 whitelist_externals = npm
@@ -15,4 +15,4 @@ deps =
 commands =
     npm install
     {toxinidir}/node_modules/.bin/webpack
-    pytest -n auto --maxfail=20 --ignore node_modules --ignore .tox
+    pytest -n auto -x --ignore node_modules --ignore .tox

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ deps =
 commands =
     npm install
     {toxinidir}/node_modules/.bin/webpack
-    pytest -n auto -x --ignore node_modules --ignore .tox
+    pytest -n auto --maxfail=20 --ignore node_modules --ignore .tox


### PR DESCRIPTION
This is the first PR that splits up changes from #772 so that we can merge smaller sets of changes until Python 3.7 is fully supported. Since Python 3.4 is end of life, this PR drops supports for this version of Python.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
