### PR TITLE
Refactoring abs, all, any and bin

### DIFF
--- a/batavia/builtins/abs.js
+++ b/batavia/builtins/abs.js
@@ -1,6 +1,6 @@
+var callables = require('../core').callables
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
-var types = require('../types')
 
 function abs(args, kwargs) {
     if (arguments.length !== 2) {
@@ -13,18 +13,15 @@ function abs(args, kwargs) {
         throw new exceptions.TypeError.$pyclass('abs() takes exactly one argument (' + args.length + ' given)')
     }
 
-    var value = args[0]
-    if (types.isinstance(value, types.Bool)) {
-        return new types.Int(Math.abs(value.valueOf()))
-    } else if (types.isinstance(value, [types.Int,
-        types.Float,
-        types.Complex])) {
-        return value.__abs__()
-    } else {
-        throw new exceptions.TypeError.$pyclass(
-            "bad operand type for abs(): '" + type_name(value) + "'")
+    const value = args[0]
+
+    if (value.__abs__) {
+        return callables.call_method(value, '__abs__', [], {})
     }
+
+    throw new exceptions.TypeError.$pyclass('bad operand type for abs(): \'' + type_name(value) + '\'')
 }
-abs.__doc__ = 'abs(number) -> number\n\nReturn the absolute value of the argument.'
+
+abs.__doc__ = 'Return the absolute value of the argument.'
 
 module.exports = abs

--- a/batavia/builtins/all.js
+++ b/batavia/builtins/all.js
@@ -1,7 +1,5 @@
 var exceptions = require('../core').exceptions
-var callables = require('../core').callables
 var type_name = require('../core').type_name
-var types = require('../types')
 
 function all(args, kwargs) {
     if (args[0] === null) {
@@ -17,24 +15,21 @@ function all(args, kwargs) {
         throw new exceptions.TypeError.$pyclass('all() takes exactly one argument (' + args.length + ' given)')
     }
 
+    var builtins = require('../builtins')
+    const iterobj = builtins.iter(args, {})
     try {
-        var iterobj = callables.call_method(args[0], '__iter__', [])
-
-        while (true) {
-            var next = callables.call_method(iterobj, '__next__', [])
-            var bool_next = callables.call_method(next, '__bool__', [])
-            if (!bool_next) {
-                return false
-            }
+        while (builtins.bool.__call__([builtins.next([iterobj], {})], {})) {
         }
+        return false
     } catch (err) {
         if (!(err instanceof exceptions.StopIteration.$pyclass)) {
             throw new exceptions.TypeError.$pyclass("'" + type_name(args[0]) + "' object is not iterable")
         }
     }
 
-    return new types.Bool(true)
+    return true
 }
-all.__doc__ = 'all(iterable) -> bool\n\nReturn True if bool(x) is True for all values x in the iterable.\nIf the iterable is empty, return True.'
+
+all.__doc__ = 'Return True if bool(x) is True for all values x in the iterable.\n\nIf the iterable is empty, return True.'
 
 module.exports = all

--- a/batavia/builtins/any.js
+++ b/batavia/builtins/any.js
@@ -1,5 +1,4 @@
 var exceptions = require('../core').exceptions
-var callables = require('../core').callables
 var type_name = require('../core').type_name
 
 function any(args, kwargs) {
@@ -16,26 +15,21 @@ function any(args, kwargs) {
         throw new exceptions.TypeError.$pyclass('any() takes exactly one argument (' + args.length + ' given)')
     }
 
-    if (!args[0].__iter__) {
-        throw new exceptions.TypeError.$pyclass("'" + type_name(args[0]) + "' object is not iterable")
-    }
-
-    var iterobj = callables.call_method(args[0], '__iter__', [])
+    var builtins = require('../builtins')
+    const iterobj = builtins.iter(args, {})
     try {
-        while (true) {
-            var next = callables.call_method(iterobj, '__next__', [])
-            var bool_next = callables.call_method(next, '__bool__', [])
-            if (bool_next) {
-                return true
-            }
+        while (!builtins.bool.__call__([builtins.next([iterobj], {})], {})) {
         }
+        return true
     } catch (err) {
         if (!(err instanceof exceptions.StopIteration.$pyclass)) {
-            throw err
+            throw new exceptions.TypeError.$pyclass("'" + type_name(args[0]) + "' object is not iterable")
         }
     }
+
     return false
 }
-any.__doc__ = 'any(iterable) -> bool\n\nReturn True if bool(x) is True for any x in the iterable.\nIf the iterable is empty, return False.'
+
+any.__doc__ = 'Return True if bool(x) is True for any x in the iterable.\n\nIf the iterable is empty, return False.'
 
 module.exports = any

--- a/batavia/builtins/bin.js
+++ b/batavia/builtins/bin.js
@@ -1,3 +1,4 @@
+var callables = require('../core').callables
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
 var types = require('../types')
@@ -13,25 +14,19 @@ function bin(args, kwargs) {
         throw new exceptions.TypeError.$pyclass('bin() takes exactly one argument (' + args.length + ' given)')
     }
 
-    var obj = args[0]
+    const obj = args[0]
 
-    if (!types.isinstance(obj, types.Int) &&
-        !types.isinstance(obj, types.Bool)) {
-        throw new exceptions.TypeError.$pyclass(
-            "'" + type_name(obj) + "' object cannot be interpreted as an integer")
+    if (!obj.__index__) {
+        throw new exceptions.TypeError.$pyclass("'" + type_name(obj) + "' object cannot be interpreted as an integer")
     }
 
-    if (types.isinstance(obj, types.Bool)) {
-        return new types.Str('0b' + obj.__int__().toString(2))
-    }
-    var binaryDigits = obj.toString(2)
-    var sign = ''
+    let binaryDigits = callables.call_method(obj, '__index__', []).toString(2)
     if (binaryDigits[0] === '-') {
-        sign = '-'
-        binaryDigits = binaryDigits.slice(1)
+        return new types.Str('-0b' + binaryDigits.slice(1))
     }
-    return new types.Str(sign + '0b' + binaryDigits)
+    return new types.Str('0b' + binaryDigits)
 }
-bin.__doc__ = 'bin(number) -> string\n\nReturn the binary representation of an integer.\n\n   '
+
+bin.__doc__ = "Return the binary representation of an integer.\n\n   >>> bin(2796202)\n   '0b1010101010101010101010'"
 
 module.exports = bin

--- a/batavia/types/Bool.js
+++ b/batavia/types/Bool.js
@@ -284,6 +284,10 @@ Bool.prototype.__int__ = function() {
     }
 }
 
+Bool.prototype.__abs__ = function() {
+    return this.__int__()
+}
+
 /**************************************************
  * Binary operators
  **************************************************/

--- a/batavia/types/Bool.js
+++ b/batavia/types/Bool.js
@@ -284,6 +284,10 @@ Bool.prototype.__int__ = function() {
     }
 }
 
+Bool.prototype.__index__ = function() {
+    return this.__int__()
+}
+
 Bool.prototype.__abs__ = function() {
     return this.__int__()
 }

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -99,6 +99,10 @@ Int.prototype.__int__ = function() {
     return this
 }
 
+Int.prototype.__index__ = function() {
+    return this
+}
+
 /**************************************************
  * Comparison operators
  **************************************************/

--- a/tests/builtins/test_abs.py
+++ b/tests/builtins/test_abs.py
@@ -12,7 +12,7 @@ class AbsTests(TranspileTestCase):
             class AbsLike:
                 def __abs__(self):
                     return 4
-                    
+
             x = AbsLike()
             print(abs(x))
         """)

--- a/tests/builtins/test_abs.py
+++ b/tests/builtins/test_abs.py
@@ -2,6 +2,21 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class AbsTests(TranspileTestCase):
+    def test_abs_doc(self):
+        self.assertCodeExecution("""
+            print(abs.__doc__)
+        """)
+
+    def test_abs_implemented(self):
+        self.assertCodeExecution("""
+            class AbsLike:
+                def __abs__(self):
+                    return 4
+                    
+            x = AbsLike()
+            print(abs(x))
+        """)
+
     def test_abs_not_implemented(self):
         self.assertCodeExecution("""
             class NotAbsLike:

--- a/tests/builtins/test_all.py
+++ b/tests/builtins/test_all.py
@@ -37,7 +37,7 @@ class AllTests(TranspileTestCase):
                 return len(self.value)
               def __getitem__(self, idx):
                 return self.value[idx]
-                
+
             not_all_values = Sequence([1,2,0,1])
             print(all(not_all_values))
             all_values = Sequence([1,2,3,1])

--- a/tests/builtins/test_all.py
+++ b/tests/builtins/test_all.py
@@ -23,6 +23,29 @@ class AllTests(TranspileTestCase):
                 print("Done.")
         """)
 
+    def test_all_doc(self):
+        self.assertCodeExecution("""
+            print(all.__doc__)
+        """)
+
+    def test_all_sequence(self):
+        self.assertCodeExecution("""
+            class Sequence:
+              def __init__(self, value):
+                self.value = value
+              def __len__(self):
+                return len(self.value)
+              def __getitem__(self, idx):
+                return self.value[idx]
+                
+            not_all_values = Sequence([1,2,0,1])
+            print(all(not_all_values))
+            all_values = Sequence([1,2,3,1])
+            print(all(all_values))
+            no_values = Sequence([0,0,0])
+            print(all(no_values))
+        """)
+
 
 class BuiltinAllFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "all"

--- a/tests/builtins/test_any.py
+++ b/tests/builtins/test_any.py
@@ -38,7 +38,7 @@ class AnyTests(TranspileTestCase):
                 return len(self.value)
               def __getitem__(self, idx):
                 return self.value[idx]
-                
+
             not_all_values = Sequence([1,2,0,1])
             print(any(not_all_values))
             all_values = Sequence([1,2,3,1])
@@ -46,7 +46,6 @@ class AnyTests(TranspileTestCase):
             no_values = Sequence([0,0,0])
             print(any(no_values))
         """)
-
 
 
 class BuiltinAnyFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_any.py
+++ b/tests/builtins/test_any.py
@@ -24,6 +24,30 @@ class AnyTests(TranspileTestCase):
                 print('Done.')
         """)
 
+    def test_any_doc(self):
+        self.assertCodeExecution("""
+            print(any.__doc__)
+        """)
+
+    def test_any_sequence(self):
+        self.assertCodeExecution("""
+            class Sequence:
+              def __init__(self, value):
+                self.value = value
+              def __len__(self):
+                return len(self.value)
+              def __getitem__(self, idx):
+                return self.value[idx]
+                
+            not_all_values = Sequence([1,2,0,1])
+            print(any(not_all_values))
+            all_values = Sequence([1,2,3,1])
+            print(any(all_values))
+            no_values = Sequence([0,0,0])
+            print(any(no_values))
+        """)
+
+
 
 class BuiltinAnyFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "any"

--- a/tests/builtins/test_bin.py
+++ b/tests/builtins/test_bin.py
@@ -18,6 +18,23 @@ class BinTests(TranspileTestCase):
                 print('Done.')
             """, run_in_function=False)
 
+    def test_index(self):
+        self.assertCodeExecution("""
+            class IntLike:
+                def __init__(self, val):
+                    self.val = val
+                def __index__(self):
+                    return self.val
+
+            x = IntLike(5)
+            print(bin(x))
+            """, run_in_function=False)
+
+    def test_bin_doc(self):
+        self.assertCodeExecution("""
+            print(bin.__doc__)
+        """)
+
 
 class BuiltinBinFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "bin"


### PR DESCRIPTION
This updates abs to support any object with an __abs__ method. (And adds an bool.__abs__)
This updates any and all to support sequences defined with __len__ and __getitem__.
This updates bin to support any object with an __index__ method. (And adds bool.__index__ and int.__index__)

Additionally abs, any, all and bin have their __doc__ strings updated from 3.4 to the 3.5-3.7 state.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
