### PR TITLE
Accounted for the length of the keyword argument + () when substituti…

### DIFF
--- a/batavia/types/StrUtils.js
+++ b/batavia/types/StrUtils.js
@@ -57,7 +57,6 @@ function _substitute(format, args) {
         // returns object containing the specifier object and the remaining unused arguments
 
         // reference: https://docs.python.org/2/library/stdtypes.html#string-formatting
-
         if (usesKwargs) {
             // try to parse the key from this spec
             var keyRe = /\((.+?)\)(.+)/
@@ -643,7 +642,6 @@ function _substitute(format, args) {
                 // example: '   0005'
                 retVal = ' '.repeat(padSize) + conversionArg
             }
-
             return retVal
         } // END TRANSFORM
 
@@ -652,6 +650,7 @@ function _substitute(format, args) {
         var nextStep = 1
         var charArray = this.fullText.slice(1).split('')
         var charIndex = 0
+
         while (charIndex < charArray.length && !this.literalPercent) {
             var nextChar = charArray[charIndex]
             this.parsedSpec += nextChar
@@ -700,6 +699,10 @@ function _substitute(format, args) {
         }
 
         lastStop = match.index + specObj.parsedSpec.length
+        if (specObj.myKey) {
+            // Add kwarg + parenthesis
+            lastStop = lastStop + 2 + specObj.myKey.length
+        }
         match = re.exec(format)
     }
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -1027,7 +1027,6 @@ class FormatTests(TranspileTestCase):
 
             self.assertCodeExecution(test, js_cleaner=js_cleaner, py_cleaner=py_cleaner)
 
-        # @unittest.expectedFailure
         @transforms(
             js_bool=False,
             decimal=False,

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -1027,7 +1027,7 @@ class FormatTests(TranspileTestCase):
 
             self.assertCodeExecution(test, js_cleaner=js_cleaner, py_cleaner=py_cleaner)
 
-        @unittest.expectedFailure
+        # @unittest.expectedFailure
         @transforms(
             js_bool=False,
             decimal=False,


### PR DESCRIPTION
When using old-style format with a dictionary, keyword args weren't being properly replaced. Seems to be fixed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ x ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
