### PR TITLE
Improve docs for Python 3.7+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ Downloading and Installing
 
 Linux/Unix/Mac
 --------------
-Check your python3 version first.  If it's pointing to version 3.6, replace ``$(which python3)`` in the virtualenv command
-below with the path to your Python 3.5 or 3.6 installation. ::
+Type the following commands in your terminal ::
 
 $ python3 --version
 $ python3 -m venv venv
@@ -77,7 +76,7 @@ $ pip install -e .
 Windows
 -------
 
-Type in the following commands in your terminal ::
+Type the following commands in your terminal ::
 
     > py -3 -m venv venv
     > venv\Scripts\activate

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -4,7 +4,7 @@ Tutorial: Setting up your Environment
 Getting a working local copy of Batavia requires a few steps: getting a copy of
 the Batavia code, and the ouroboros dependency within a virtual environment.
 
-You'll need to have Python 3.5 or 3.6 available for Batavia to work.
+You'll need to have Python 3.5, 3.6 or 3.7 available for Batavia to work.
 Instructions on how to set this up are `on our Environment setup guide
 <http://beeware.org/contributing/how/first-time/setup/>`_.
 

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -187,4 +187,9 @@ to run this code. It's not overly concerning, though, as the main
 use case here is basic DOM manipulation and responding to button clicks, not
 heavy computation.
 
+As an aside, if you'd like to run more than a trivial performance benchmark,
+please check out `pyperf`_ and `pyperformance`_.
+
 .. _removed in 3.7: https://bugs.python.org/issue15369#msg276231
+.. _pyperf: https://pyperf.readthedocs.io/
+.. _pyperformance: https://pyperformance.readthedocs.io/

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -173,7 +173,8 @@ There are also a couple of "Run PyStone" buttons, each of which runs for a
 number of iterations. PyStone is a performance benchmark. On an average modern
 PC, the 5 loop version will be almost instantaneous; 500 loops will take less
 than a second; 50000 loops will take about 15 seconds. You can compare this with
-native performance by running the following in a Python shell::
+native performance by running the following in a Python (3.6 or earlier, as
+``test.pystone`` was `removed in 3.7`_) shell::
 
     >>> from test import pystone
     >>> pystone.main()
@@ -185,3 +186,5 @@ CPython. This is to be expected -- Batavia is going through a very complex proce
 to run this code. It's not overly concerning, though, as the main
 use case here is basic DOM manipulation and responding to button clicks, not
 heavy computation.
+
+.. _removed in 3.7: https://bugs.python.org/issue15369#msg276231


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This PR modifies the `README.rst` and tutorials to:
- make Python 3.7 support more explicit
- [drop an old reference to "$(which python3)"](
https://github.com/beeware/batavia/commit/f5694f29324f7422cb13b50f08eeb50644927496) noting also that the supported Python versions are already present earlier in the [README.rst file's prerequisites](https://github.com/beeware/batavia/blob/d49c5f7/README.rst#prerequisites) section (as an aside `which` usage could be improved with [`command -v`](https://github.com/koalaman/shellcheck/wiki/SC2230))
- document the caveat that [`test.pystone` was removed from the standard library in 3.7](https://bugs.python.org/issue15369#msg276231)
- add the suggestion to check out [pyperf](https://pyperf.readthedocs.io/) and [pyperformance](https://pyperformance.readthedocs.io/) as an aside to tutorial 1

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested (N/A)
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
